### PR TITLE
Feat/add code quality script

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,29 @@
+---
+policies:
+  - type: commit
+    spec:
+      dco: true
+      gpg:
+        required: true
+      header:
+        length: 200
+        imperative: true
+        case: lower
+        invalidLastCharacters: .
+      body:
+        required: false
+      conventional:
+        types:
+          [
+            "chore",
+            "build",
+            "docs",
+            "ci",
+            "perf",
+            "refactor",
+            "style",
+            "test",
+            "release",
+          ]
+        scopes: [".*"]
+        descriptionLength: 92

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+
+**/*.md
+megalinter-reports

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,15 @@
+---
+plugins:
+  - "@prettier/plugin-xml"
+#
+# This enables automated whitespace formatting of XML files.
+# However, there is a slight risk that this can introduce semantic changes.
+# In those, expectedly rare, cases we can disable formatting selectively using
+# either the .prettierignore file or by using ignore ranges:
+# <foo>
+#  <!-- prettier-ignore-start -->
+#    <this-content-will-not-be-formatted     />
+#  <!-- prettier-ignore-end -->
+# </foo>
+#
+xmlWhitespaceSensitivity: "ignore"

--- a/.secretlintignore
+++ b/.secretlintignore
@@ -1,0 +1,6 @@
+/config/common/rootca/rootca_private_key.pem
+/config/issuer/issuer_private_key.pem
+/config/keycloak/certs/keycloak.tls.key
+/config/traefik/certs/wallet-key.pem
+/config/verifier/verifier_private_key.pem
+/config/wallet-provider/wallet_provider_private_key.pem

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,8 +4,56 @@ This guide outlines core essentials for developing in this project.
 
 ## Table of Contents
 
+- [Setup and Configuration](#setup-and-configuration)
+  - [IDE Setup](#ide-setup)
 - [Development Workflow](#development-workflow)
   - [Pull Request Process](#pull-request-workflow)
+
+## Setup and Configuration
+
+### IDE Setup
+
+Run the code quality script.
+
+```shell
+./development/code_quality.sh
+```
+
+This will run the automated test suite
+and other automation such as linters and formatters.
+As a side effect all required dependencies will be downloaded.
+After running the script, please take a look in
+[the generated IDE configuration file](./megalinter-reports/IDE-config.txt).
+It contains a list of suggested plugins and configuration for various editors and IDEs,
+e.g. VS Code and IntelliJ.
+
+#### VSCode
+
+ 1. Install plugins:
+
+    - [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+    - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+    - [ShellCheck](https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck)
+    - [shell-format](https://marketplace.visualstudio.com/items?itemName=foxundermoon.shell-format) version 7.2.5
+
+        **Note 1:** There is
+        [a known issue](https://github.com/foxundermoon/vs-shell-format/issues/396)
+        with version 7.2.8 of shell-format
+        preventing it from being detected as a formatter for shell scripts.
+        Please use version 7.2.5 until the issue is fixed.
+
+        **Note 2:** You need to have the `shfmt` binary installed in order to use the plugin.
+        On Ubuntu you can install it with `sudo apt-get install shfmt`.
+
+ 2. Open workspace settings - settings.json (for example with Ctrl+Shift+P → Preferences: Workspace Settings (JSON)) and add:
+
+    ```json
+    "editor.formatOnSave": true,
+    "shellformat.path": "<path to shfmt>",
+    "[markdown]": {
+        "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+    },
+    ```
 
 ## Development Workflow
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,12 +68,15 @@ you need a recent version of
 As of this writing, the default version on macOS is version 3.2,
 which is too old.
 You can install a later version using [Homebrew](https://brew.sh/) like so:
+
 ```shell
 brew install bash
 ```
+
 This should get you version 5.3 or later.
 
 You can check your bash version like this:
+
 ```shell
 bash --version
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,25 @@ e.g. VS Code and IntelliJ.
 
 ### Pull Request Workflow
 
+#### Pull Request Workflow Prerequisites
+
+In order to run the code quality script,
+you need a recent version of
+[the Bash shell](https://www.gnu.org/software/bash/)
+(version 4.0 or newer) with support for associative arrays.
+As of this writing, the default version on macOS is version 3.2,
+which is too old.
+You can install a later version using [Homebrew](https://brew.sh/) like so:
+```shell
+brew install bash
+```
+This should get you version 5.3 or later.
+
+You can check your bash version like this:
+```shell
+bash --version
+```
+
 #### Running Code Quality Checks Locally
 
 1. Run the quality check script:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,26 @@
+# Development Guide
+
+This guide outlines core essentials for developing in this project.
+
+## Table of Contents
+
+- [Development Workflow](#development-workflow)
+  - [Pull Request Process](#pull-request-workflow)
+
+## Development Workflow
+
+### Pull Request Workflow
+
+#### Running Code Quality Checks Locally
+
+1. Run the quality check script:
+
+   ```shell
+   ./development/code_quality.sh
+   ```
+
+2. Fix any identified issues
+
+3. Update your PR with fixes
+
+4. Verify CI passes in the updated PR

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,7 @@ This guide outlines core essentials for developing in this project.
 
 ### IDE Setup
 
-Run the code quality script.
+[Run the code quality script](#running-code-quality-checks-locally).
 
 ```shell
 ./development/code_quality.sh
@@ -84,6 +84,20 @@ bash --version
 
    ```shell
    ./development/code_quality.sh
+   ```
+
+   **Note:**
+   If you are behind a corporate proxy you might experience problems
+   where the script hangs for several minutes
+   while it tries to download files from the internet
+   and eventually times out.
+   To avoid this problem you can set the enviroment variable
+   `MEGALINTER_SKIP_LINTER_OUTPUT_SANITIZATION=true`.
+   For instance, you could configure the variable in your global settings,
+   or run the script like so:
+
+   ```shell
+   env MEGALINTER_SKIP_LINTER_OUTPUT_SANITIZATION=true development/code_quality.sh
    ```
 
 2. Fix any identified issues

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-![Logo](https://raw.githubusercontent.com/swedenconnect/technical-framework/master/img/sweden-connect.png)
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-
 # Digg Wallet Local Development Environment
 
 Docker compose scripts for starting Digg Wallet environment services locally.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following prerequisites are needed for running the scrips:
 - Edit your computer's hosts-file to contain mappings from `127.0.0.1`
   to local services at `*.wallet.local`
 
-```
+```text
 #
 # Host Database
 #

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -178,6 +178,6 @@ true || lint
 true || commit
 true || verify
 true || license
-true || version_control
+version_control
 
 check_exit_codes

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -140,12 +140,14 @@ Please accept or discard any outstanding changes and try again.${NC}\n\n" \
   printf '\n\n'
 }
 
-# coverage() {
-#   print_header 'COVERAGE (JACOCO)'
-#   mvn clean verify "${MAVEN_CLI_OPTS[@]}" -Dcoverage -Djacoco.fail=true
-#   store_exit_code "$?" "Coverage" "${MISSING} ${RED}Coverage check failed, see logs (./target/jacoco-report/index.html) and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Coverage check passed${NC}\n"
-#   printf '\n\n'
-# }
+coverage() {
+  print_header 'COVERAGE (JACOCO)'
+  mvn clean verify "${MAVEN_CLI_OPTS[@]}" -Dcoverage -Djacoco.fail=true
+  store_exit_code "$?" "Coverage" \
+    "${MISSING} ${RED}Coverage check failed, see logs (./target/jacoco-report/index.html) and fix problems.${NC}\n" \
+    "${GREEN}${CHECKMARK}${CHECKMARK} Coverage check passed${NC}\n"
+  printf '\n\n'
+}
 
 check_exit_codes() {
   printf '%b********* CODE QUALITY RUN SUMMARY ******%b\n\n' "${YELLOW}" "${NC}"
@@ -177,6 +179,7 @@ is_command_available 'sed' ''
 lint
 commit
 true || verify
+true || coverage
 true || license
 version_control
 

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -175,7 +175,7 @@ is_command_available 'npm' 'https://nodejs.org/'
 is_command_available 'sed' ''
 
 true || lint
-true || commit
+commit
 true || verify
 true || license
 version_control

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -174,7 +174,7 @@ is_command_available 'node' 'https://nodejs.org/'
 is_command_available 'npm' 'https://nodejs.org/'
 is_command_available 'sed' ''
 
-true || lint
+lint
 commit
 true || verify
 true || license

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+# Run a code quality check
+
+# bash strict mode - undefined vars, propagate pipefails
+set -uo pipefail
+
+declare -A EXITCODES=()
+declare -A SUCCESS_MESSAGES=()
+
+readonly RED=$'\e[31m'
+readonly NC=$'\e[0m'
+readonly GREEN=$'\e[32m'
+readonly YELLOW=$'\e[0;33m'
+readonly FAIL_EMOJI='\xf0\x9f\x98\xb1'
+readonly HAPPY_EMOJI='\xf0\x9f\x98\x80'
+
+#Terminal chars
+readonly CHECKMARK=$'\xE2\x9C\x94'
+readonly MISSING=$'\xE2\x9D\x8C'
+
+#MAVEN OPTS
+readonly MAVEN_CLI_OPTS=(--batch-mode --no-transfer-progress --errors --fail-at-end -Dstyle.color=always -DinstallAtEnd=true -DdeployAtEnd=true)
+
+# Determine container runtime
+CONTAINER_RUNTIME=""
+
+determine_container_runtime() {
+  if command -v podman &>/dev/null; then
+    CONTAINER_RUNTIME="podman"
+  elif command -v docker &>/dev/null; then
+    CONTAINER_RUNTIME="docker"
+  else
+    printf '%b Error:%b Neither podman https://podman.io/ nor docker https://docker.io/ is available in path/installed.\n' "${RED}" "${NC}" >&2
+    exit 1
+  fi
+}
+
+is_command_available() {
+  local COMMAND="${1}"
+  local INFO="${2}"
+
+  if ! [ -x "$(command -v "${COMMAND}")" ]; then
+    printf '%b Error:%b %s is not availble in path/installed.\n' "${RED}" "${NC}" "${COMMAND}" >&2
+    printf 'See %s for more info about the command.\n' "${INFO}" >&2
+    exit 1
+  fi
+}
+
+print_header() {
+  local HEADER="$1"
+  printf '%b\n************ %s ***********%b\n\n' "${YELLOW}" "$HEADER" "${NC}"
+}
+
+store_exit_code() {
+  declare -i STATUS="$1"
+  local KEY="$2"
+  local INVALID_MESSAGE="$3"
+  local VALID_MESSAGE="$4"
+
+  if [[ "${STATUS}" -ne 0 ]]; then
+    EXITCODES["${KEY}"]="${INVALID_MESSAGE}"
+  else
+    SUCCESS_MESSAGES["${KEY}"]="${VALID_MESSAGE}"
+  fi
+}
+
+lint() {
+  export MEGALINTER_DEF_WORKSPACE='/github/workspace'
+  print_header 'LINTER HEALTH (MEGALINTER)'
+  # Pre-emptively install node packages to avoid issues with corporate proxy.
+  npm install
+  ${CONTAINER_RUNTIME} run --rm --volume "$(pwd)":${MEGALINTER_DEF_WORKSPACE} \
+    -e MEGALINTER_CONFIG='development/megalinter.yml' \
+    -e DEFAULT_WORKSPACE=${MEGALINTER_DEF_WORKSPACE} \
+    -e SKIP_LINTER_OUTPUT_SANITIZATION="${MEGALINTER_SKIP_LINTER_OUTPUT_SANITIZATION:-false}" \
+    -e LOG_LEVEL=INFO \
+    ghcr.io/oxsecurity/megalinter-java:v8.8.0
+  store_exit_code "$?" "Lint" \
+    "${MISSING} ${RED}Lint check failed, see logs (std out and/or ./megalinter-reports) and fix problems.${NC}\n" \
+    "${GREEN}${CHECKMARK}${CHECKMARK} Lint check passed${NC}\n"
+  printf '\n\n'
+}
+
+license() {
+  print_header 'LICENSE HEALTH (REUSE)'
+  ${CONTAINER_RUNTIME} run --rm --volume "$(pwd)":/data docker.io/fsfe/reuse:5.0.2-debian lint
+  store_exit_code "$?" "License" \
+    "${MISSING} ${RED}License check failed, see logs and fix problems.${NC}\n" \
+    "${GREEN}${CHECKMARK}${CHECKMARK} License check passed${NC}\n"
+  printf '\n\n'
+}
+
+commit() {
+  local compareToBranch="${COMMIT_COMPARE_TO_BRANCH:-main}"
+  local currentBranch
+  currentBranch=$(git branch --show-current)
+  print_header 'COMMIT HEALTH (CONFORM)'
+
+  if [[ "$(git rev-list --count "${compareToBranch}"..)" == 0 ]]; then
+    printf "%s" \
+      "${GREEN} No commits found in current branch: ${YELLOW}${currentBranch}${NC}, compared to: ${YELLOW}${compareToBranch}${NC} ${NC}"
+    store_exit_code "$?" "Commit" \
+      "${MISSING} ${RED}Commit check count failed, see logs (std out) and fix problems.${NC}\n" \
+      "${YELLOW}${CHECKMARK}${CHECKMARK} Commit check skipped, no new commits found in current branch: ${YELLOW}${currentBranch}${NC}\n"
+  else
+    ${CONTAINER_RUNTIME} run --rm -i --volume "$(pwd)":/repo -w /repo \
+      ghcr.io/siderolabs/conform:v0.1.0-alpha.30-2-gfadbbb4 \
+      enforce --base-branch="${compareToBranch}"
+    store_exit_code "$?" "Commit" \
+      "${MISSING} ${RED}Commit check failed, see logs (std out) and fix problems.${NC}\n" \
+      "${GREEN}${CHECKMARK}${CHECKMARK} Commit check passed${NC}\n"
+  fi
+
+  printf '\n\n'
+}
+
+verify() {
+  print_header 'VERIFY'
+  mvn verify "${MAVEN_CLI_OPTS[@]}"
+  store_exit_code "$?" "Verify" \
+    "${MISSING} ${RED}Verify check failed, see logs (std out) and fix problems.${NC}\n" \
+    "${GREEN}${CHECKMARK}${CHECKMARK} Verify check passed${NC}\n"
+  printf '\n\n'
+}
+
+version_control() {
+  print_header 'VERSION CONTROL'
+  git status
+  test -z "$(git status --porcelain | awk '{$1=$1};1')"
+  store_exit_code "$?" "Version control" \
+    "${MISSING} ${RED}Some changes are not under version control! \
+This can happen if
+
+  1. You forgot to version control your changes
+  2. A linter automatically fixed a problem or reformatted the code.
+
+Please accept or discard any outstanding changes and try again.${NC}\n\n" \
+    "${GREEN}${CHECKMARK}${CHECKMARK} Version control check passed${NC}\n"
+  printf '\n\n'
+}
+
+# coverage() {
+#   print_header 'COVERAGE (JACOCO)'
+#   mvn clean verify "${MAVEN_CLI_OPTS[@]}" -Dcoverage -Djacoco.fail=true
+#   store_exit_code "$?" "Coverage" "${MISSING} ${RED}Coverage check failed, see logs (./target/jacoco-report/index.html) and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Coverage check passed${NC}\n"
+#   printf '\n\n'
+# }
+
+check_exit_codes() {
+  printf '%b********* CODE QUALITY RUN SUMMARY ******%b\n\n' "${YELLOW}" "${NC}"
+
+  for key in "${!EXITCODES[@]}"; do
+    printf '%b' "${EXITCODES[$key]}"
+  done
+  printf "\n"
+
+  for key in "${!SUCCESS_MESSAGES[@]}"; do
+    printf '%b' "${SUCCESS_MESSAGES[$key]}"
+  done
+  printf "\n"
+
+  if [[ "${#EXITCODES[@]}" -gt 0 ]]; then
+    printf '%s %b\n' "${RED}${#EXITCODES[@]} of the code quality checks failed!${NC}" "${FAIL_EMOJI}"
+    exit 1
+  else
+    printf '%s%b\n' "${GREEN}${CHECKMARK} All code quality checks passed!${NC}" "${HAPPY_EMOJI}"
+    exit 0
+  fi
+}
+
+determine_container_runtime
+is_command_available 'node' 'https://nodejs.org/'
+is_command_available 'npm' 'https://nodejs.org/'
+is_command_available 'sed' ''
+
+true || lint
+true || commit
+true || verify
+true || license
+true || version_control
+
+check_exit_codes

--- a/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
+++ b/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
@@ -1,0 +1,73 @@
+descriptor_id: DIGG_XML
+descriptor_type: format
+descriptor_flavors:
+  - all_flavors # Any project can contain XML
+  - ci_light
+  - cupcake
+file_extensions:
+  - ".xml"
+  - ".xsd"
+linters:
+  - name: DIGG_XML_PRETTIER
+    linter_name: prettier-xml
+    linter_text: |
+      **@prettier/plugin-xml** is a prettier plugin for XML. prettier is an opinionated code formatter that supports multiple languages and integrates with most editors. The idea is to eliminate discussions of style in code review and allow developers to get back to thinking about code design instead.
+    is_formatter: true
+    linter_url: https://github.com/prettier/plugin-xml
+    linter_spdx_license: MIT
+    linter_rules_url: https://github.com/prettier/plugin-xml?tab=readme-ov-file#configuration
+    linter_rules_inline_disable_url: https://github.com/prettier/plugin-xml?tab=readme-ov-file#ignore-ranges
+    linter_banner_image_url: https://github.com/standard/standard/raw/master/sticker.png
+    config_file_name: ".prettierrc.yml"
+    ignore_file_name: ".prettierignore"
+    cli_executable: "prettier"
+    cli_lint_mode: list_of_files
+    cli_lint_errors_count: regex_count
+    cli_lint_errors_regex: "\\[error\\]"
+    cli_lint_warnings_count: regex_count
+    cli_lint_warnings_regex: "\\[warn\\]"
+    cli_lint_extra_args:
+      - "--plugin=@prettier/plugin-xml"
+      - "--check"
+    cli_lint_fix_arg_name: "--write"
+    cli_lint_fix_remove_args:
+      - "--check"
+    examples:
+      - "prettier --plugin=@prettier/plugin-xml --write '**/*.xml'" # format
+    install:
+      #
+      # These instructions unfortunately do not work.
+      # There is a note in the MegaLinter documentation about this.
+      # https://megalinter.io/latest/plugins/
+      #
+      # When using this plugin,
+      # you must make sure that Prettier and the XML plugin are installed on the
+      # host, e.g. in the local node_modules.
+      #
+      npm:
+        - "prettier@3.6.2"
+        - "@prettier/plugin-xml@3.4.2"
+    ide:
+      emacs:
+        - name: prettier-emacs
+          url: https://github.com/prettier/prettier-emacs
+        - name: prettier.el
+          url: https://github.com/jscheid/prettier.el
+        - name: apheleia
+          url: https://github.com/raxod502/apheleia
+      idea:
+        - name: Prettier
+          url: https://plugins.jetbrains.com/plugin/10456-prettier
+          id: intellij.prettierJS
+      sublime:
+        - name: JsPrettier
+          url: https://packagecontrol.io/packages/JsPrettier
+      vim:
+        - name: vim-prettier
+          url: https://github.com/prettier/vim-prettier
+      visual_studio:
+        - name: JavaScriptPrettier
+          url: https://github.com/madskristensen/JavaScriptPrettier
+      vscode:
+        - name: prettier-vscode
+          url: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode

--- a/development/megalinter.yml
+++ b/development/megalinter.yml
@@ -1,0 +1,62 @@
+---
+# Configuration file for MegaLinter.
+# See configuration options at https://oxsecurity.github.io/megalinter/configuration/ and more in each linter documentation.
+
+PLUGINS:
+  - file:///github/workspace/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
+
+# General
+PRINT_ALPACA: false
+APPLY_FIXES: all
+
+DISABLE_ERRORS: false
+FAIL_IF_UPDATED_SOURCES: true
+FORMATTERS_DISABLE_ERRORS: false
+SHOW_ELAPSED_TIME: true
+SHOW_SKIPPED_LINTERS: false
+
+# Reporter options
+CLEAR_REPORT_FOLDER: true
+EMAIL_REPORTER: false
+TEXT_REPORTER: true
+SARIF_REPORTER: true
+GITHUB_COMMENT_REPORTER: true
+GITHUB_STATUS_REPORTER: true
+GITLAB_COMMENT_REPORTER: false
+UPDATED_SOURCES_REPORTER: true
+
+# Lint specific settings
+ENABLE_LINTERS:
+  [
+    ACTION_ACTIONLINT,
+    BASH_SHELLCHECK,
+    BASH_SHFMT,
+    JAVA_CHECKSTYLE,
+    JAVA_PMD,
+    MARKDOWN_MARKDOWNLINT,
+    REPOSITORY_SECRETLINT,
+    XML_XMLLINT,
+    DIGG_XML_PRETTIER,
+    YAML_PRETTIER,
+  ]
+
+DOCKERFILE_HADOLINT_FILE_NAMES_REGEX: ["Containerfile.*"]
+BASH_SHFMT_ARGUMENTS: -i 2
+BASH_SHFMT_FILE_EXTENSIONS: [.sh]
+BASH_SHELLCHECK_FILE_EXTENSIONS: [.sh]
+JAVA_CHECKSTYLE_CLI_EXECUTABLE:
+  ["java", "-Dorg.checkstyle.google.severity=ERROR"]
+JAVA_CHECKSTYLE_FILTER_REGEX_INCLUDE: src
+JAVA_CHECKSTYLE_CONFIG_FILE: development/lint/google_checks.xml
+JAVA_PMD_CONFIG_FILE: development/sast/pmd_default_java.xml
+REPOSITORY_GITLEAKS_ARGUMENTS: detect --log-opts="main..HEAD"
+# LOG_LEVEL: DEBUG # will show you the exact command run
+PRE_COMMANDS:
+  # Install node packages.
+  # This is useful for custom plugins that require additional node packages.
+  # For instance, the Prettier XML plugin requires 'prettier'
+  # and '@prettier/plugin-xml'.
+  # Please make sure they are in your package.json.
+  - command: npm install --include=dev
+    cwd: workspace
+    continue_if_failed: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "wallet-ecosystem",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wallet-ecosystem",
+      "devDependencies": {
+        "@prettier/plugin-xml": "^3.4.2",
+        "prettier": "^3.6.2"
+      }
+    },
+    "node_modules/@prettier/plugin-xml": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.2.tgz",
+      "integrity": "sha512-/UyNlHfkuLXG6Ed85KB0WBF283xn2yavR+UtRibBRUcvEJId2DSLdGXwJ/cDa1X++SWDPzq3+GSFniHjkNy7yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xml-tools/parser": "^1.0.11"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/@xml-tools/parser": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@xml-tools/parser/-/parser-1.0.11.tgz",
+      "integrity": "sha512-aKqQ077XnR+oQtHJlrAflaZaL7qZsulWc/i/ZEooar5JiWj1eLt0+Wg28cpa+XLney107wXqneC+oG1IZvxkTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chevrotain": "7.1.1"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.1.tgz",
+      "integrity": "sha512-wy3mC1x4ye+O+QkEinVJkPf5u2vsrDIYW9G7ZuwFl6v/Yu0LwUuT2POsb+NUWApebyxfkQq6+yDfRExbnI5rcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-to-ast": "0.5.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "wallet-ecosystem",
+  "devDependencies": {
+    "@prettier/plugin-xml": "^3.4.2",
+    "prettier": "^3.6.2"
+  }
+}

--- a/set-host.sh
+++ b/set-host.sh
@@ -2,7 +2,8 @@
 # Resolve the IP address of host.docker.internal and store it in HOST_IP
 
 export SET_HOST_EXTRA_PARAM='--add-host=host.docker.internal:host-gateway'
-export HOST_IP=$(docker run --rm $SET_HOST_EXTRA_PARAM alpine sh -c 'ping -c 1 host.docker.internal | grep PING | awk "{ print \$3 }" | tr -d "(): "')
+HOST_IP=$(docker run --rm $SET_HOST_EXTRA_PARAM alpine sh -c 'ping -c 1 host.docker.internal | grep PING | awk "{ print \$3 }" | tr -d "(): "')
+export HOST_IP
 
 # Output the HOST_IP for debugging (optional)
 echo "Resolved HOST_IP: $HOST_IP"


### PR DESCRIPTION
This change set adds a way to automatically run code quality checks such as linters and other tools. It is heavily based on the scripts in [wallet-provider](https://github.com/diggsweden/wallet-provider/) and adapts them to the needs of this project. Specifically we have yet no need for Java specific checks in this project. Also, the license check is still disabled and remains to be implemented at a later stage.

To run the checks, you can use the command below:

        development/code_quality.sh

Note: This requires a recent version of the Bash shell. On MacOS you might need to install another version than the default one. If you use [homebrew](https://brew.sh/), you can use `brew install bash`.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
