### PR TITLE
Feat/add licenses

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 ---
 policies:
   - type: commit

--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 ---
 policies:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 # EditorConfig is awesome: https://editorconfig.org
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 # EditorConfig is awesome: https://editorconfig.org
 
 # top-most EditorConfig file

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 #
 # Intelij
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 #
 # Intelij

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
 
 **/*.md
 megalinter-reports

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 **/*.md
 megalinter-reports

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 ---
 plugins:

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 ---
 plugins:
   - "@prettier/plugin-xml"

--- a/.secretlintignore.license
+++ b/.secretlintignore.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/.secretlintignore.license
+++ b/.secretlintignore.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/.secretlintignore.license
+++ b/.secretlintignore.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2
 -->

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Development Guide

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2
+-->
+
 # Development Guide
 
 This guide outlines core essentials for developing in this project.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/EUPL-1.2.txt
+++ b/LICENSES/EUPL-1.2.txt
@@ -1,0 +1,190 @@
+EUROPEAN UNION PUBLIC LICENCE v. 1.2
+EUPL © the European Union 2007, 2016
+
+This European Union Public Licence (the ‘EUPL’) applies to the Work (as defined below) which is provided under the
+terms of this Licence. Any use of the Work, other than as authorised under this Licence is prohibited (to the extent such
+use is covered by a right of the copyright holder of the Work).
+The Work is provided under the terms of this Licence when the Licensor (as defined below) has placed the following
+notice immediately following the copyright notice for the Work:
+                          Licensed under the EUPL
+or has expressed by any other means his willingness to license under the EUPL.
+
+1.Definitions
+In this Licence, the following terms have the following meaning:
+— ‘The Licence’:this Licence.
+— ‘The Original Work’:the work or software distributed or communicated by the Licensor under this Licence, available
+as Source Code and also as Executable Code as the case may be.
+— ‘Derivative Works’:the works or software that could be created by the Licensee, based upon the Original Work or
+modifications thereof. This Licence does not define the extent of modification or dependence on the Original Work
+required in order to classify a work as a Derivative Work; this extent is determined by copyright law applicable in
+the country mentioned in Article 15.
+— ‘The Work’:the Original Work or its Derivative Works.
+— ‘The Source Code’:the human-readable form of the Work which is the most convenient for people to study and
+modify.
+— ‘The Executable Code’:any code which has generally been compiled and which is meant to be interpreted by
+a computer as a program.
+— ‘The Licensor’:the natural or legal person that distributes or communicates the Work under the Licence.
+— ‘Contributor(s)’:any natural or legal person who modifies the Work under the Licence, or otherwise contributes to
+the creation of a Derivative Work.
+— ‘The Licensee’ or ‘You’:any natural or legal person who makes any usage of the Work under the terms of the
+Licence.
+— ‘Distribution’ or ‘Communication’:any act of selling, giving, lending, renting, distributing, communicating,
+transmitting, or otherwise making available, online or offline, copies of the Work or providing access to its essential
+functionalities at the disposal of any other natural or legal person.
+
+2.Scope of the rights granted by the Licence
+The Licensor hereby grants You a worldwide, royalty-free, non-exclusive, sublicensable licence to do the following, for
+the duration of copyright vested in the Original Work:
+— use the Work in any circumstance and for all usage,
+— reproduce the Work,
+— modify the Work, and make Derivative Works based upon the Work,
+— communicate to the public, including the right to make available or display the Work or copies thereof to the public
+and perform publicly, as the case may be, the Work,
+— distribute the Work or copies thereof,
+— lend and rent the Work or copies thereof,
+— sublicense rights in the Work or copies thereof.
+Those rights can be exercised on any media, supports and formats, whether now known or later invented, as far as the
+applicable law permits so.
+In the countries where moral rights apply, the Licensor waives his right to exercise his moral right to the extent allowed
+by law in order to make effective the licence of the economic rights here above listed.
+The Licensor grants to the Licensee royalty-free, non-exclusive usage rights to any patents held by the Licensor, to the
+extent necessary to make use of the rights granted on the Work under this Licence.
+
+3.Communication of the Source Code
+The Licensor may provide the Work either in its Source Code form, or as Executable Code. If the Work is provided as
+Executable Code, the Licensor provides in addition a machine-readable copy of the Source Code of the Work along with
+each copy of the Work that the Licensor distributes or indicates, in a notice following the copyright notice attached to
+the Work, a repository where the Source Code is easily and freely accessible for as long as the Licensor continues to
+distribute or communicate the Work.
+
+4.Limitations on copyright
+Nothing in this Licence is intended to deprive the Licensee of the benefits from any exception or limitation to the
+exclusive rights of the rights owners in the Work, of the exhaustion of those rights or of other applicable limitations
+thereto.
+
+5.Obligations of the Licensee
+The grant of the rights mentioned above is subject to some restrictions and obligations imposed on the Licensee. Those
+obligations are the following:
+
+Attribution right: The Licensee shall keep intact all copyright, patent or trademarks notices and all notices that refer to
+the Licence and to the disclaimer of warranties. The Licensee must include a copy of such notices and a copy of the
+Licence with every copy of the Work he/she distributes or communicates. The Licensee must cause any Derivative Work
+to carry prominent notices stating that the Work has been modified and the date of modification.
+
+Copyleft clause: If the Licensee distributes or communicates copies of the Original Works or Derivative Works, this
+Distribution or Communication will be done under the terms of this Licence or of a later version of this Licence unless
+the Original Work is expressly distributed only under this version of the Licence — for example by communicating
+‘EUPL v. 1.2 only’. The Licensee (becoming Licensor) cannot offer or impose any additional terms or conditions on the
+Work or Derivative Work that alter or restrict the terms of the Licence.
+
+Compatibility clause: If the Licensee Distributes or Communicates Derivative Works or copies thereof based upon both
+the Work and another work licensed under a Compatible Licence, this Distribution or Communication can be done
+under the terms of this Compatible Licence. For the sake of this clause, ‘Compatible Licence’ refers to the licences listed
+in the appendix attached to this Licence. Should the Licensee's obligations under the Compatible Licence conflict with
+his/her obligations under this Licence, the obligations of the Compatible Licence shall prevail.
+
+Provision of Source Code: When distributing or communicating copies of the Work, the Licensee will provide
+a machine-readable copy of the Source Code or indicate a repository where this Source will be easily and freely available
+for as long as the Licensee continues to distribute or communicate the Work.
+Legal Protection: This Licence does not grant permission to use the trade names, trademarks, service marks, or names
+of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the copyright notice.
+
+6.Chain of Authorship
+The original Licensor warrants that the copyright in the Original Work granted hereunder is owned by him/her or
+licensed to him/her and that he/she has the power and authority to grant the Licence.
+Each Contributor warrants that the copyright in the modifications he/she brings to the Work are owned by him/her or
+licensed to him/her and that he/she has the power and authority to grant the Licence.
+Each time You accept the Licence, the original Licensor and subsequent Contributors grant You a licence to their contributions
+to the Work, under the terms of this Licence.
+
+7.Disclaimer of Warranty
+The Work is a work in progress, which is continuously improved by numerous Contributors. It is not a finished work
+and may therefore contain defects or ‘bugs’ inherent to this type of development.
+For the above reason, the Work is provided under the Licence on an ‘as is’ basis and without warranties of any kind
+concerning the Work, including without limitation merchantability, fitness for a particular purpose, absence of defects or
+errors, accuracy, non-infringement of intellectual property rights other than copyright as stated in Article 6 of this
+Licence.
+This disclaimer of warranty is an essential part of the Licence and a condition for the grant of any rights to the Work.
+
+8.Disclaimer of Liability
+Except in the cases of wilful misconduct or damages directly caused to natural persons, the Licensor will in no event be
+liable for any direct or indirect, material or moral, damages of any kind, arising out of the Licence or of the use of the
+Work, including without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, loss
+of data or any commercial damage, even if the Licensor has been advised of the possibility of such damage. However,
+the Licensor will be liable under statutory product liability laws as far such laws apply to the Work.
+
+9.Additional agreements
+While distributing the Work, You may choose to conclude an additional agreement, defining obligations or services
+consistent with this Licence. However, if accepting obligations, You may act only on your own behalf and on your sole
+responsibility, not on behalf of the original Licensor or any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against such Contributor by
+the fact You have accepted any warranty or additional liability.
+
+10.Acceptance of the Licence
+The provisions of this Licence can be accepted by clicking on an icon ‘I agree’ placed under the bottom of a window
+displaying the text of this Licence or by affirming consent in any other similar way, in accordance with the rules of
+applicable law. Clicking on that icon indicates your clear and irrevocable acceptance of this Licence and all of its terms
+and conditions.
+Similarly, you irrevocably accept this Licence and all of its terms and conditions by exercising any rights granted to You
+by Article 2 of this Licence, such as the use of the Work, the creation by You of a Derivative Work or the Distribution
+or Communication by You of the Work or copies thereof.
+
+11.Information to the public
+In case of any Distribution or Communication of the Work by means of electronic communication by You (for example,
+by offering to download the Work from a remote location) the distribution channel or media (for example, a website)
+must at least provide to the public the information requested by the applicable law regarding the Licensor, the Licence
+and the way it may be accessible, concluded, stored and reproduced by the Licensee.
+
+12.Termination of the Licence
+The Licence and the rights granted hereunder will terminate automatically upon any breach by the Licensee of the terms
+of the Licence.
+Such a termination will not terminate the licences of any person who has received the Work from the Licensee under
+the Licence, provided such persons remain in full compliance with the Licence.
+
+13.Miscellaneous
+Without prejudice of Article 9 above, the Licence represents the complete agreement between the Parties as to the
+Work.
+If any provision of the Licence is invalid or unenforceable under applicable law, this will not affect the validity or
+enforceability of the Licence as a whole. Such provision will be construed or reformed so as necessary to make it valid
+and enforceable.
+The European Commission may publish other linguistic versions or new versions of this Licence or updated versions of
+the Appendix, so far this is required and reasonable, without reducing the scope of the rights granted by the Licence.
+New versions of the Licence will be published with a unique version number.
+All linguistic versions of this Licence, approved by the European Commission, have identical value. Parties can take
+advantage of the linguistic version of their choice.
+
+14.Jurisdiction
+Without prejudice to specific agreement between parties,
+— any litigation resulting from the interpretation of this License, arising between the European Union institutions,
+bodies, offices or agencies, as a Licensor, and any Licensee, will be subject to the jurisdiction of the Court of Justice
+of the European Union, as laid down in article 272 of the Treaty on the Functioning of the European Union,
+— any litigation arising between other parties and resulting from the interpretation of this License, will be subject to
+the exclusive jurisdiction of the competent court where the Licensor resides or conducts its primary business.
+
+15.Applicable Law
+Without prejudice to specific agreement between parties,
+— this Licence shall be governed by the law of the European Union Member State where the Licensor has his seat,
+resides or has his registered office,
+— this licence shall be governed by Belgian law if the Licensor has no seat, residence or registered office inside
+a European Union Member State.
+
+
+                                                         Appendix
+
+‘Compatible Licences’ according to Article 5 EUPL are:
+— GNU General Public License (GPL) v. 2, v. 3
+— GNU Affero General Public License (AGPL) v. 3
+— Open Software License (OSL) v. 2.1, v. 3.0
+— Eclipse Public License (EPL) v. 1.0
+— CeCILL v. 2.0, v. 2.1
+— Mozilla Public Licence (MPL) v. 2
+— GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3
+— Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) for works other than software
+— European Union Public Licence (EUPL) v. 1.1, v. 1.2
+— Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) or Strong Reciprocity (LiLiQ-R+).
+
+The European Commission may update this Appendix to later versions of the above licences without producing
+a new version of the EUPL, as long as they provide the rights granted in Article 2 of this Licence and protect the
+covered Source Code from exclusive appropriation.
+All other changes or additions to this Appendix require the production of a new EUPL version.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2
 -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Digg Wallet Local Development Environment

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2
+-->
+
 # Digg Wallet Local Development Environment
 
 Docker compose scripts for starting Digg Wallet environment services locally.

--- a/config/common/rootca/rootca.pem.license
+++ b/config/common/rootca/rootca.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/common/rootca/rootca.pem.license
+++ b/config/common/rootca/rootca.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/common/rootca/rootca.pem.license
+++ b/config/common/rootca/rootca.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/common/rootca/rootca.srl.license
+++ b/config/common/rootca/rootca.srl.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/common/rootca/rootca.srl.license
+++ b/config/common/rootca/rootca.srl.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/common/rootca/rootca.srl.license
+++ b/config/common/rootca/rootca.srl.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/common/rootca/rootca_private_key.pem.license
+++ b/config/common/rootca/rootca_private_key.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/common/rootca/rootca_private_key.pem.license
+++ b/config/common/rootca/rootca_private_key.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/common/rootca/rootca_private_key.pem.license
+++ b/config/common/rootca/rootca_private_key.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer.csr.license
+++ b/config/issuer/issuer.csr.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/issuer/issuer.csr.license
+++ b/config/issuer/issuer.csr.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer.csr.license
+++ b/config/issuer/issuer.csr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_cert.p12.license
+++ b/config/issuer/issuer_cert.p12.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/issuer/issuer_cert.p12.license
+++ b/config/issuer/issuer_cert.p12.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_cert.p12.license
+++ b/config/issuer/issuer_cert.p12.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_cert.pem.license
+++ b/config/issuer/issuer_cert.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/issuer/issuer_cert.pem.license
+++ b/config/issuer/issuer_cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_cert.pem.license
+++ b/config/issuer/issuer_cert.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_chain.pem.license
+++ b/config/issuer/issuer_chain.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/issuer/issuer_chain.pem.license
+++ b/config/issuer/issuer_chain.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_chain.pem.license
+++ b/config/issuer/issuer_chain.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_private_key.pem.license
+++ b/config/issuer/issuer_private_key.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/issuer/issuer_private_key.pem.license
+++ b/config/issuer/issuer_private_key.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/issuer/issuer_private_key.pem.license
+++ b/config/issuer/issuer_private_key.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/keycloak/certs/keycloak.tls.crt.license
+++ b/config/keycloak/certs/keycloak.tls.crt.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 European Commission
+
+SPDX-License-Identifier: Apache-2.0

--- a/config/keycloak/certs/keycloak.tls.key.license
+++ b/config/keycloak/certs/keycloak.tls.key.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 European Commission
+
+SPDX-License-Identifier: Apache-2.0

--- a/config/keycloak/extra/health-check.sh.license
+++ b/config/keycloak/extra/health-check.sh.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 European Commission
+
+SPDX-License-Identifier: Apache-2.0

--- a/config/keycloak/realms/pid-issuer-realm-realm.json.license
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 European Commission
+
+SPDX-License-Identifier: Apache-2.0

--- a/config/keycloak/realms/pid-issuer-realm-users-0.json.license
+++ b/config/keycloak/realms/pid-issuer-realm-users-0.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 European Commission
+
+SPDX-License-Identifier: Apache-2.0

--- a/config/traefik/tls.yml
+++ b/config/traefik/tls.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 tls:
   certificates:

--- a/config/traefik/tls.yml
+++ b/config/traefik/tls.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 tls:
   certificates:
     - certFile: /certs/wallet-cert.pem

--- a/config/traefik/tls.yml
+++ b/config/traefik/tls.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/config/verifier/refimpl-verifier-backend-keystore.jks.license
+++ b/config/verifier/refimpl-verifier-backend-keystore.jks.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/verifier/refimpl-verifier-backend-keystore.jks.license
+++ b/config/verifier/refimpl-verifier-backend-keystore.jks.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/refimpl-verifier-backend-keystore.jks.license
+++ b/config/verifier/refimpl-verifier-backend-keystore.jks.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier.csr.license
+++ b/config/verifier/verifier.csr.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/verifier/verifier.csr.license
+++ b/config/verifier/verifier.csr.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier.csr.license
+++ b/config/verifier/verifier.csr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_cert.p12.license
+++ b/config/verifier/verifier_cert.p12.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/verifier/verifier_cert.p12.license
+++ b/config/verifier/verifier_cert.p12.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_cert.p12.license
+++ b/config/verifier/verifier_cert.p12.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_cert.pem.license
+++ b/config/verifier/verifier_cert.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/verifier/verifier_cert.pem.license
+++ b/config/verifier/verifier_cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_cert.pem.license
+++ b/config/verifier/verifier_cert.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_chain.pem.license
+++ b/config/verifier/verifier_chain.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/verifier/verifier_chain.pem.license
+++ b/config/verifier/verifier_chain.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_chain.pem.license
+++ b/config/verifier/verifier_chain.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_private_key.pem.license
+++ b/config/verifier/verifier_private_key.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/verifier/verifier_private_key.pem.license
+++ b/config/verifier/verifier_private_key.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/verifier/verifier_private_key.pem.license
+++ b/config/verifier/verifier_private_key.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/refimpl-verifier-backend-keystore.jks.license
+++ b/config/wallet-provider/refimpl-verifier-backend-keystore.jks.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/wallet-provider/refimpl-verifier-backend-keystore.jks.license
+++ b/config/wallet-provider/refimpl-verifier-backend-keystore.jks.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/refimpl-verifier-backend-keystore.jks.license
+++ b/config/wallet-provider/refimpl-verifier-backend-keystore.jks.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider.csr.license
+++ b/config/wallet-provider/wallet_provider.csr.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/wallet-provider/wallet_provider.csr.license
+++ b/config/wallet-provider/wallet_provider.csr.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider.csr.license
+++ b/config/wallet-provider/wallet_provider.csr.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider.p12.license
+++ b/config/wallet-provider/wallet_provider.p12.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/wallet-provider/wallet_provider.p12.license
+++ b/config/wallet-provider/wallet_provider.p12.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider.p12.license
+++ b/config/wallet-provider/wallet_provider.p12.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_cert.p12.license
+++ b/config/wallet-provider/wallet_provider_cert.p12.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/wallet-provider/wallet_provider_cert.p12.license
+++ b/config/wallet-provider/wallet_provider_cert.p12.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_cert.p12.license
+++ b/config/wallet-provider/wallet_provider_cert.p12.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_cert.pem.license
+++ b/config/wallet-provider/wallet_provider_cert.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/wallet-provider/wallet_provider_cert.pem.license
+++ b/config/wallet-provider/wallet_provider_cert.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_cert.pem.license
+++ b/config/wallet-provider/wallet_provider_cert.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_chain.pem.license
+++ b/config/wallet-provider/wallet_provider_chain.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/wallet-provider/wallet_provider_chain.pem.license
+++ b/config/wallet-provider/wallet_provider_chain.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_chain.pem.license
+++ b/config/wallet-provider/wallet_provider_chain.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_private_key.pem.license
+++ b/config/wallet-provider/wallet_provider_private_key.pem.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/config/wallet-provider/wallet_provider_private_key.pem.license
+++ b/config/wallet-provider/wallet_provider_private_key.pem.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/config/wallet-provider/wallet_provider_private_key.pem.license
+++ b/config/wallet-provider/wallet_provider_private_key.pem.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 # Run a code quality check
 
 # bash strict mode - undefined vars, propagate pipefails

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -184,7 +184,7 @@ lint
 commit
 true || verify
 true || coverage
-true || license
+license
 version_control
 
 check_exit_codes

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
+++ b/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 descriptor_id: DIGG_XML
 descriptor_type: format
 descriptor_flavors:

--- a/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
+++ b/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
+++ b/development/mega-linter-plugin-prettier-xml/prettier-xml.megalinter-descriptor.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 descriptor_id: DIGG_XML
 descriptor_type: format

--- a/development/megalinter.yml
+++ b/development/megalinter.yml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 ---
 # Configuration file for MegaLinter.

--- a/development/megalinter.yml
+++ b/development/megalinter.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/development/megalinter.yml
+++ b/development/megalinter.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 ---
 # Configuration file for MegaLinter.
 # See configuration options at https://oxsecurity.github.io/megalinter/configuration/ and more in each linter documentation.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 name: wallet-ecosystem-local
 
 networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
-# SPDX-License-Identifier: EUPL-1.2
+# SPDX-License-Identifier: CC0-1.0
 
 name: wallet-ecosystem-local
 

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
-SPDX-License-Identifier: EUPL-1.2
+SPDX-License-Identifier: CC0-1.0

--- a/package.json.license
+++ b/package.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 Digg Sweden
+SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: EUPL-1.2

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2025 Digg Sweden
+
+SPDX-License-Identifier: EUPL-1.2

--- a/set-host.fish
+++ b/set-host.fish
@@ -1,4 +1,9 @@
 #!/usr/bin/fish
+
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 # Resolve the IP address of host.docker.internal and store it in HOST_IP
 set -Ux SET_HOST_EXTRA_PARAM --add-host=host.docker.internal:host-gateway
 set -Ux HOST_IP $(docker run --rm $SET_HOST_EXTRA_PARAM alpine sh -c 'ping -c 1 host.docker.internal | grep PING | awk "{ print \$3 }" | tr -d "(): "')

--- a/set-host.fish
+++ b/set-host.fish
@@ -1,6 +1,6 @@
 #!/usr/bin/fish
 
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/set-host.sh
+++ b/set-host.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2025 Digg Sweden
+# SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: EUPL-1.2
 

--- a/set-host.sh
+++ b/set-host.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 Digg Sweden
+#
+# SPDX-License-Identifier: EUPL-1.2
+
 # Resolve the IP address of host.docker.internal and store it in HOST_IP
 
 export SET_HOST_EXTRA_PARAM='--add-host=host.docker.internal:host-gateway'


### PR DESCRIPTION
This change set adds license information to all files:

1. The Keycloak configuration was copied from the reference implementation and have the Apache 2.0 license
2. The rest of the files are licensed under EUPL 1.2

We also enable the license check in the code quality script.

The license information was added using the `reuse` tool. Please see the individual commits for the exact command used.

See: https://reuse.software/
See: https://github.com/eu-digital-identity-wallet/eudi-srv-pid-issuer

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
