### PR TITLE
Feat/expose on localhost

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,6 +83,18 @@ docker-compose up -d
 mvn test
 ```
 
+**Note:** Some of our services uses a custom host mapping,
+e.g. `refimpl-verifier.wallet.local`.
+On machines where the user cannot change the hosts mapping
+the automated tests that try to use a service using such a host name will fail.
+To workaround this problem,
+you can skip those tests by setting an environment variable
+and run the test suite like so:
+
+```shell
+env DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_USING_CUSTOM_HOSTS=true mvn test
+```
+
 ### Pull Request Workflow
 
 #### Pull Request Workflow Prerequisites

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,8 +72,8 @@ The main goals of this suite are:
  2. To verify that those services can communicate with each other, and
  3. To simplify manual exploration and learning.
 
- At the current stage the test suite is just a skeleton.
- However, we except to grow the suite over time.
+At the current stage the test suite is just a skeleton.
+However, we except to grow the suite over time.
 
 In order to run the test suite from the command line,
 use the commands below:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ After this, the local environment can be started by:
 * [Strumpsorteringscentralen](https://localhost/custom-verifier),
   our custom verifier
 * [EUs reference implementation of a verifier](https://refimpl-verifier.wallet.local)
-* [EUs reference implementation of a verifier backend](https://refimpl-verifier-backend.wallet.local),
+* [EUs reference implementation of a verifier backend](https://localhost/refimpl-verifier-backend),
   used by both above
 * [Wallet provider](https://wallet-provider.wallet.local),
   our service to issue and control the lifecycle of Wallet Unit of Attestations (WUA).
@@ -65,7 +65,6 @@ The following prerequisites are needed for running the scrips:
 # Digg Wallet Ecosystem
 #
 127.0.0.1       refimpl-verifier.wallet.local
-127.0.0.1       refimpl-verifier-backend.wallet.local
 127.0.0.1       wallet-provider.wallet.local
 127.0.0.1       pid-issuer.wallet.local
 127.0.0.1       keycloak.wallet.local

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ The following prerequisites are needed for running the scrips:
 # Digg Wallet Ecosystem
 #
 127.0.0.1       refimpl-verifier.wallet.local
-127.0.0.1       pid-issuer.wallet.local
 127.0.0.1       keycloak.wallet.local
 127.0.0.1       traefik.wallet.local
 127.0.0.1       wallet-account.wallet.local

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ After this, the local environment can be started by:
 * [EUs reference implementation of a verifier backend](https://localhost/refimpl-verifier-backend),
   used by both above
 * [EUs reference implementation of a PID issuer](https://localhost/pid-issuer)
+* [Keycloak](https://localhost/keycloak/idp),
+  identity provider for the PID issuer
 * [Wallet provider](https://localhost/wallet-provider),
   our service to issue and control the lifecycle of Wallet Unit of Attestations (WUA).
 * [Traefik](http://localhost:8080),

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ The following prerequisites are needed for running the scrips:
 # Digg Wallet Ecosystem
 #
 127.0.0.1       refimpl-verifier.wallet.local
-127.0.0.1       traefik.wallet.local
 127.0.0.1       wallet-account.wallet.local
 127.0.0.1       wallet-client-gateway.wallet.local
 127.0.0.1       wallet-attribute-attestation.wallet.local

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ After this, the local environment can be started by:
 ---
 ## Services
 
-* [Strumpsorteringscentralen](https://custom-verifier.wallet.local),
+* [Strumpsorteringscentralen](https://localhost/custom-verifier),
   our custom verifier
 * [EUs reference implementation of a verifier](https://refimpl-verifier.wallet.local)
 * [EUs reference implementation of a verifier backend](https://refimpl-verifier-backend.wallet.local),
@@ -64,7 +64,6 @@ The following prerequisites are needed for running the scrips:
 
 # Digg Wallet Ecosystem
 #
-127.0.0.1       custom-verifier.wallet.local
 127.0.0.1       refimpl-verifier.wallet.local
 127.0.0.1       refimpl-verifier-backend.wallet.local
 127.0.0.1       wallet-provider.wallet.local

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After this, the local environment can be started by:
 * [EUs reference implementation of a verifier](https://refimpl-verifier.wallet.local)
 * [EUs reference implementation of a verifier backend](https://localhost/refimpl-verifier-backend),
   used by both above
-* [Wallet provider](https://wallet-provider.wallet.local),
+* [Wallet provider](https://localhost/wallet-provider),
   our service to issue and control the lifecycle of Wallet Unit of Attestations (WUA).
 * [Traefik](http://localhost:8080),
   used for TLS
@@ -65,7 +65,6 @@ The following prerequisites are needed for running the scrips:
 # Digg Wallet Ecosystem
 #
 127.0.0.1       refimpl-verifier.wallet.local
-127.0.0.1       wallet-provider.wallet.local
 127.0.0.1       pid-issuer.wallet.local
 127.0.0.1       keycloak.wallet.local
 127.0.0.1       traefik.wallet.local

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ After this, the local environment can be started by:
 * [EUs reference implementation of a verifier](https://refimpl-verifier.wallet.local)
 * [EUs reference implementation of a verifier backend](https://localhost/refimpl-verifier-backend),
   used by both above
+* [EUs reference implementation of a PID issuer](https://localhost/pid-issuer)
 * [Wallet provider](https://localhost/wallet-provider),
   our service to issue and control the lifecycle of Wallet Unit of Attestations (WUA).
 * [Traefik](http://localhost:8080),

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ After this, the local environment can be started by:
 * [EUs reference implementation of a verifier backend](https://localhost/refimpl-verifier-backend),
   used by both above
 * [EUs reference implementation of a PID issuer](https://localhost/pid-issuer)
-* [Keycloak](https://localhost/keycloak/idp),
+* [Keycloak](https://localhost/idp),
   identity provider for the PID issuer
 * [Wallet provider](https://localhost/wallet-provider),
   our service to issue and control the lifecycle of Wallet Unit of Attestations (WUA).

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ The following prerequisites are needed for running the scrips:
 # Digg Wallet Ecosystem
 #
 127.0.0.1       refimpl-verifier.wallet.local
-127.0.0.1       wallet-account.wallet.local
 127.0.0.1       wallet-client-gateway.wallet.local
 127.0.0.1       wallet-attribute-attestation.wallet.local
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The following prerequisites are needed for running the scrips:
 # Digg Wallet Ecosystem
 #
 127.0.0.1       refimpl-verifier.wallet.local
-127.0.0.1       keycloak.wallet.local
 127.0.0.1       traefik.wallet.local
 127.0.0.1       wallet-account.wallet.local
 127.0.0.1       wallet-client-gateway.wallet.local

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ The following prerequisites are needed for running the scrips:
 #
 127.0.0.1       refimpl-verifier.wallet.local
 127.0.0.1       wallet-client-gateway.wallet.local
-127.0.0.1       wallet-attribute-attestation.wallet.local
 ```
 
 ### Certificate for TLS

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ After this, the local environment can be started by:
 > docker compose up
 
 ---
+
 ## Services
 
 * [Strumpsorteringscentralen](https://localhost/custom-verifier),
@@ -42,6 +43,7 @@ After this, the local environment can be started by:
   our service to issue and control the lifecycle of Wallet Unit of Attestations (WUA).
 * [Traefik](http://localhost:8080),
   used for TLS
+  
 ---
 
 ## Building Images

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ The following prerequisites are needed for running the scrips:
 # Digg Wallet Ecosystem
 #
 127.0.0.1       refimpl-verifier.wallet.local
-127.0.0.1       wallet-client-gateway.wallet.local
 ```
 
 ### Certificate for TLS

--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -459,7 +459,7 @@
     "totpAppFreeOTPName",
     "totpAppGoogleName"
   ],
-  "webAuthnPolicyRpEntityName": "https://localhost/idp",
+  "webAuthnPolicyRpEntityName": "https://localhost/keycloak/idp",
   "webAuthnPolicySignatureAlgorithms": [
     "ES256",
     "ES384",
@@ -474,7 +474,7 @@
   "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyAcceptableAaguids": [],
   "webAuthnPolicyExtraOrigins": [],
-  "webAuthnPolicyPasswordlessRpEntityName": "https://localhost/idp",
+  "webAuthnPolicyPasswordlessRpEntityName": "https://localhost/keycloak/idp",
   "webAuthnPolicyPasswordlessSignatureAlgorithms": [
     "ES256",
     "ES384",

--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -459,7 +459,7 @@
     "totpAppFreeOTPName",
     "totpAppGoogleName"
   ],
-  "webAuthnPolicyRpEntityName": "https://localhost/keycloak/idp",
+  "webAuthnPolicyRpEntityName": "https://localhost/idp",
   "webAuthnPolicySignatureAlgorithms": [
     "ES256",
     "ES384",
@@ -474,7 +474,7 @@
   "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyAcceptableAaguids": [],
   "webAuthnPolicyExtraOrigins": [],
-  "webAuthnPolicyPasswordlessRpEntityName": "https://localhost/keycloak/idp",
+  "webAuthnPolicyPasswordlessRpEntityName": "https://localhost/idp",
   "webAuthnPolicyPasswordlessSignatureAlgorithms": [
     "ES256",
     "ES384",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -424,6 +424,3 @@ services:
       - "traefik.enable=true"
     networks:
       wallet-ecosystem-network:
-        aliases:
-          - refimpl-verifier.wallet.local
-          - wallet-attribute-attestation-db.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,9 +126,9 @@ services:
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_SECRET=zIKAV9DIIIaJCzHCVBPlySgU8KgY68U2
       - SERVER_FORWARD_HEADERS_STRATEGY=FRAMEWORK
       - ISSUER_PUBLICURL=https://localhost/pid-issuer
-      - ISSUER_AUTHORIZATIONSERVER_PUBLICURL=https://keycloak.wallet.local/idp/realms/pid-issuer-realm
-      - ISSUER_AUTHORIZATIONSERVER_METADATA=https://keycloak:8443/idp/realms/pid-issuer-realm/.well-known/openid-configuration
-      - ISSUER_AUTHORIZATIONSERVER_INTROSPECTION=https://keycloak:8443/idp/realms/pid-issuer-realm/protocol/openid-connect/token/introspect
+      - ISSUER_AUTHORIZATIONSERVER_PUBLICURL=https://localhost/keycloak/idp/realms/pid-issuer-realm
+      - ISSUER_AUTHORIZATIONSERVER_METADATA=https://keycloak:8443/keycloak/idp/realms/pid-issuer-realm/.well-known/openid-configuration
+      - ISSUER_AUTHORIZATIONSERVER_INTROSPECTION=https://keycloak:8443/keycloak/idp/realms/pid-issuer-realm/protocol/openid-connect/token/introspect
       - ISSUER_CREDENTIALRESPONSEENCRYPTION_SUPPORTED=true
       - ISSUER_CREDENTIALRESPONSEENCRYPTION_REQUIRED=true
       - ISSUER_CREDENTIALRESPONSEENCRYPTION_ALGORITHMSSUPPORTED=ECDH-ES
@@ -147,7 +147,7 @@ services:
       - ISSUER_MDL_NOTIFICATIONS_ENABLED=true
       - ISSUER_CREDENTIALOFFER_URI=openid-credential-offer://
       - ISSUER_SIGNING_KEY=GenerateRandom
-      - ISSUER_KEYCLOAK_SERVER_URL=https://keycloak:8443/idp
+      - ISSUER_KEYCLOAK_SERVER_URL=https://keycloak:8443/keycloak/idp
       - ISSUER_KEYCLOAK_AUTHENTICATION_REALM=master
       - ISSUER_KEYCLOAK_CLIENT_ID=admin-cli
       - ISSUER_KEYCLOAK_USERNAME=admin
@@ -348,8 +348,8 @@ services:
     environment:
       - KC_PROXY_HEADERS=xforwarded
       - KC_HTTP_ENABLED=true
-      - KC_HTTP_RELATIVE_PATH=/idp
-      - KC_HOSTNAME=https://keycloak.wallet.local/idp
+      - KC_HTTP_RELATIVE_PATH=/keycloak/idp
+      - KC_HOSTNAME=https://localhost/keycloak/idp
       - KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true
       - KC_HTTPS_CERTIFICATE_FILE=/etc/ssl/certs/keycloak.tls.crt
       - KC_HTTPS_CERTIFICATE_KEY_FILE=/etc/ssl/certs/keycloak.tls.key
@@ -368,14 +368,14 @@ services:
       - ./config/keycloak/certs/:/etc/ssl/certs/
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.keycloak.rule=Host(`keycloak.wallet.local`)"
+      - "traefik.http.routers.keycloak.rule=PathPrefix(`/keycloak`)"
       - "traefik.http.routers.keycloak.entrypoints=websecure"
       - "traefik.http.routers.keycloak.tls=true"
       - "traefik.http.routers.keycloak.service=keycloak"
       - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
       - "traefik.http.routers.keycloak.middlewares=keycloak-replace-path"
-      - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.regex=^/.well-known/([a-zA-Z-]+)/idp/realms/([a-zA-Z-]+)/?"
-      - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.replacement=/idp/realms/$2/.well-known/$1"
+      - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.regex=^/keycloak/.well-known/([a-zA-Z-]+)/idp/realms/([a-zA-Z-]+)/?"
+      - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.replacement=/keycloak/idp/realms/$2/.well-known/$1"
     networks:
       - wallet-ecosystem-network
 
@@ -415,4 +415,3 @@ services:
           - wallet-attribute-attestation-db.wallet.local
           - wallet-attribute-attestation.wallet.local
           - wallet-client-gateway.wallet.local
-          - keycloak.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -262,6 +262,7 @@ services:
     volumes:
       - ./config/common/Healthcheck.class:/opt/Healthcheck.class:ro
     environment:
+      SERVER_SERVLET_CONTEXT_PATH: "/wallet-account"
       SPRING_PROFILES_ACTIVE: "prod"
       TZ: "Europe/Stockholm"
       JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
@@ -282,14 +283,14 @@ services:
           "--class-path",
           "/opt",
           "Healthcheck",
-          "http://localhost:8080/actuator/health",
+          "http://localhost:8080/wallet-account/actuator/health",
         ]
       start_period: 5s
       interval: 5s
       retries: 5
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.wallet-account.rule=Host(`wallet-account.wallet.local`)"
+      - "traefik.http.routers.wallet-account.rule=PathPrefix(`/wallet-account`)"
       - "traefik.http.routers.wallet-account.entrypoints=websecure"
       - "traefik.http.routers.wallet-account.tls=true"
       - "traefik.http.routers.wallet-account.service=wallet-account"
@@ -312,7 +313,7 @@ services:
       PROPERTIES_WALLETPROVIDER_BASEURL: "http://wallet-provider:8080/wallet-provider"
       PROPERTIES_WALLETPROVIDER_WUAPATH: "/wallet-unit-attestation"
       PROPERTIES_ATTRIBUTEATTESTATION_BASEURL: "http://wallet-attribute-attestation:8080"
-      PROPERTIES_WALLETACCOUNT_BASEURL: "http://wallet-account:8080"
+      PROPERTIES_WALLETACCOUNT_BASEURL: "http://wallet-account:8080/wallet-account"
     ports:
       - "8082:8080"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -376,6 +376,13 @@ services:
       - "traefik.http.routers.keycloak.middlewares=keycloak-replace-path"
       - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.regex=^/keycloak/.well-known/([a-zA-Z-]+)/idp/realms/([a-zA-Z-]+)/?"
       - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.replacement=/idp/realms/$2/.well-known/$1"
+      - "traefik.http.routers.well-known-oauth-server.rule=PathPrefix(`/.well-known/oauth-authorization-server`)"
+      - "traefik.http.routers.well-known-oauth-server.entrypoints=websecure"
+      - "traefik.http.routers.well-known-oauth-server.tls=true"
+      - "traefik.http.routers.well-known-oauth-server.service=keycloak"
+      - "traefik.http.routers.well-known-oauth-server.middlewares=well-known-oauth-server-replace-path"
+      - "traefik.http.middlewares.well-known-oauth-server-replace-path.replacepathregex.regex=^/.well-known/([a-zA-Z-]+)/idp/realms/([a-zA-Z-]+)/?"
+      - "traefik.http.middlewares.well-known-oauth-server-replace-path.replacepathregex.replacement=/idp/realms/$2/.well-known/$1"
     networks:
       - wallet-ecosystem-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -419,9 +419,6 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.dashboard-secure.entrypoints=websecure"
-      - "traefik.http.routers.dashboard-secure.tls=true"
-      - "traefik.http.routers.dashboard-secure.service=api@internal"
     networks:
       wallet-ecosystem-network:
         aliases:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -204,6 +204,7 @@ services:
     volumes:
       - ./config/common/Healthcheck.class:/opt/Healthcheck.class:ro
     environment:
+      SERVER_SERVLET_CONTEXT_PATH: "/wallet-attribute-attestation"
       SPRING_PROFILES_ACTIVE: "prod"
       TZ: "Europe/Stockholm"
       JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
@@ -224,14 +225,14 @@ services:
           "--class-path",
           "/opt",
           "Healthcheck",
-          "http://localhost:8080/actuator/health",
+          "http://localhost:8080/wallet-attribute-attestation/actuator/health",
         ]
       start_period: 5s
       interval: 5s
       retries: 5
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.wallet-attribute-attestation.rule=Host(`wallet-attribute-attestation.wallet.local`)"
+      - "traefik.http.routers.wallet-attribute-attestation.rule=PathPrefix(`/wallet-attribute-attestation`)"
       - "traefik.http.routers.wallet-attribute-attestation.entrypoints=websecure"
       - "traefik.http.routers.wallet-attribute-attestation.tls=true"
       - "traefik.http.routers.wallet-attribute-attestation.service=wallet-attribute-attestation"
@@ -312,7 +313,7 @@ services:
       PROPERTIES_APISECRET: "apikey"
       PROPERTIES_WALLETPROVIDER_BASEURL: "http://wallet-provider:8080/wallet-provider"
       PROPERTIES_WALLETPROVIDER_WUAPATH: "/wallet-unit-attestation"
-      PROPERTIES_ATTRIBUTEATTESTATION_BASEURL: "http://wallet-attribute-attestation:8080"
+      PROPERTIES_ATTRIBUTEATTESTATION_BASEURL: "http://wallet-attribute-attestation:8080/wallet-attribute-attestation"
       PROPERTIES_WALLETACCOUNT_BASEURL: "http://wallet-account:8080/wallet-account"
     ports:
       - "8082:8080"
@@ -425,5 +426,4 @@ services:
         aliases:
           - refimpl-verifier.wallet.local
           - wallet-attribute-attestation-db.wallet.local
-          - wallet-attribute-attestation.wallet.local
           - wallet-client-gateway.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,8 @@ services:
       - ./config/verifier/refimpl-verifier-backend-keystore.jks:/opt/common/refimpl-verifier-backend-keystore.jks:ro
       - ./config/verifier/verifier_cert.p12:/opt/common/verifier_cert.p12:ro
     environment:
-      VERIFIER_PUBLICURL: "https://refimpl-verifier-backend.wallet.local"
+      SPRING_WEBFLUX_BASEPATH: "/refimpl-verifier-backend"
+      VERIFIER_PUBLICURL: "https://localhost/refimpl-verifier-backend"
       VERIFIER_ORIGINALCLIENTID: "refimpl-verifier-backend.wallet.local"
       VERIFIER_CLIENTIDPREFIX: "x509_san_dns"
       VERIFIER_JAR_SIGNING_ALGORITHM: "ES256"
@@ -36,7 +37,7 @@ services:
       LOGGING_LEVEL_EU_EUROPA_EC_EUDI_VERIFIER_ENDPOINT: "DEBUG"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.refimpl-verifier-backend.rule=Host(`refimpl-verifier-backend.wallet.local`)"
+      - "traefik.http.routers.refimpl-verifier-backend.rule=PathPrefix(`/refimpl-verifier-backend`)"
       - "traefik.http.routers.refimpl-verifier-backend.entrypoints=websecure"
       - "traefik.http.routers.refimpl-verifier-backend.tls=true"
       - "traefik.http.routers.refimpl-verifier-backend.service=refimpl-verifier-backend"
@@ -72,7 +73,7 @@ services:
     container_name: custom-verifier
     hostname: custom-verifier
     environment:
-      HOST_API: "https://refimpl-verifier-backend.wallet.local"
+      HOST_API: "http://refimpl-verifier-backend:8080/refimpl-verifier-backend"
       PORT: "3002"
       NITRO_PORT: "3002"
       NUXT_PUBLIC_BASE_URL: "https://localhost/custom-verifier"
@@ -100,7 +101,7 @@ services:
       retries: 3
     environment:
       DOMAIN_NAME: "refimpl-verifier.wallet.local"
-      HOST_API: "https://refimpl-verifier-backend.wallet.local"
+      HOST_API: "https://localhost/refimpl-verifier-backend"
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.refimpl-verifier.rule=Host(`refimpl-verifier.wallet.local`)"
@@ -409,7 +410,6 @@ services:
     networks:
       wallet-ecosystem-network:
         aliases:
-          - refimpl-verifier-backend.wallet.local
           - refimpl-verifier.wallet.local
           - wallet-provider.wallet.local
           - pid-issuer.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -120,12 +120,12 @@ services:
         condition: service_healthy
     environment:
       - SPRING_PROFILES_ACTIVE=insecure
-      - SPRING_WEBFLUX_BASE_PATH=/
+      - SPRING_WEBFLUX_BASE_PATH=/pid-issuer
       - SERVER_PORT=8080
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_ID=pid-issuer-srv
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_SECRET=zIKAV9DIIIaJCzHCVBPlySgU8KgY68U2
       - SERVER_FORWARD_HEADERS_STRATEGY=FRAMEWORK
-      - ISSUER_PUBLICURL=https://pid-issuer.wallet.local
+      - ISSUER_PUBLICURL=https://localhost/pid-issuer
       - ISSUER_AUTHORIZATIONSERVER_PUBLICURL=https://keycloak.wallet.local/idp/realms/pid-issuer-realm
       - ISSUER_AUTHORIZATIONSERVER_METADATA=https://keycloak:8443/idp/realms/pid-issuer-realm/.well-known/openid-configuration
       - ISSUER_AUTHORIZATIONSERVER_INTROSPECTION=https://keycloak:8443/idp/realms/pid-issuer-realm/protocol/openid-connect/token/introspect
@@ -162,7 +162,7 @@ services:
       - ISSUER_CNONCE_EXPIRATION=PT5M
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.pid-issuer.rule=Host(`pid-issuer.wallet.local`)"
+      - "traefik.http.routers.pid-issuer.rule=PathPrefix(`/pid-issuer`)"
       - "traefik.http.routers.pid-issuer.entrypoints=websecure"
       - "traefik.http.routers.pid-issuer.tls=true"
       - "traefik.http.routers.pid-issuer.service=pid-issuer"
@@ -412,7 +412,6 @@ services:
       wallet-ecosystem-network:
         aliases:
           - refimpl-verifier.wallet.local
-          - pid-issuer.wallet.local
           - wallet-attribute-attestation-db.wallet.local
           - wallet-attribute-attestation.wallet.local
           - wallet-client-gateway.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,6 +52,7 @@ services:
     volumes:
       - ./config/wallet-provider/wallet_provider_cert.p12:/opt/common/wallet_provider_cert.p12
     environment:
+      SERVER_SERVLET_CONTEXT_PATH: "/wallet-provider"
       SPRING_PROFILES_ACTIVE: "prod"
       TZ: "Europe/Stockholm"
       JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
@@ -60,7 +61,7 @@ services:
       WUA_KEYSTORE_ALIAS: "wallet_provider_cert"
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.wallet-provider.rule=Host(`wallet-provider.wallet.local`)"
+      - "traefik.http.routers.wallet-provider.rule=PathPrefix(`/wallet-provider`)"
       - "traefik.http.routers.wallet-provider.entrypoints=websecure"
       - "traefik.http.routers.wallet-provider.tls=true"
       - "traefik.http.routers.wallet-provider.service=wallet-provider"
@@ -301,7 +302,7 @@ services:
       JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
       SERVER_PORT: "8080"
       PROPERTIES_APISECRET: "apikey"
-      PROPERTIES_WALLETPROVIDER_BASEURL: "http://wallet-provider:8080"
+      PROPERTIES_WALLETPROVIDER_BASEURL: "http://wallet-provider:8080/wallet-provider"
       PROPERTIES_WALLETPROVIDER_WUAPATH: "/wallet-unit-attestation"
       PROPERTIES_ATTRIBUTEATTESTATION_BASEURL: "http://wallet-attribute-attestation:8080"
       PROPERTIES_WALLETACCOUNT_BASEURL: "http://wallet-account:8080"
@@ -411,7 +412,6 @@ services:
       wallet-ecosystem-network:
         aliases:
           - refimpl-verifier.wallet.local
-          - wallet-provider.wallet.local
           - pid-issuer.wallet.local
           - wallet-attribute-attestation-db.wallet.local
           - wallet-attribute-attestation.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,14 +75,14 @@ services:
       HOST_API: "https://refimpl-verifier-backend.wallet.local"
       PORT: "3002"
       NITRO_PORT: "3002"
-      PUBLIC_BASE_URL: "https://custom-verifier.wallet.local"
-      NUXT_PUBLIC_BASE_URL: "https://custom-verifier.wallet.local"
+      NUXT_PUBLIC_BASE_URL: "https://localhost/custom-verifier"
+      NUXT_APP_BASE_URL: "/custom-verifier"
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
     depends_on:
       - refimpl-verifier-backend
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.custom-verifier.rule=Host(`custom-verifier.wallet.local`)"
+      - "traefik.http.routers.custom-verifier.rule=PathPrefix(`/custom-verifier`)"
       - "traefik.http.routers.custom-verifier.entrypoints=websecure"
       - "traefik.http.routers.custom-verifier.tls=true"
       - "traefik.http.services.custom-verifier.loadbalancer.server.port=3002"
@@ -411,7 +411,6 @@ services:
         aliases:
           - refimpl-verifier-backend.wallet.local
           - refimpl-verifier.wallet.local
-          - custom-verifier.wallet.local
           - wallet-provider.wallet.local
           - pid-issuer.wallet.local
           - wallet-attribute-attestation-db.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -166,6 +166,13 @@ services:
       - "traefik.http.routers.pid-issuer.entrypoints=websecure"
       - "traefik.http.routers.pid-issuer.tls=true"
       - "traefik.http.routers.pid-issuer.service=pid-issuer"
+      - "traefik.http.routers.well-known-pid-issuer.rule=PathRegexp(`^/.well-known/([a-zA-Z-]+)/pid-issuer$`)"
+      - "traefik.http.routers.well-known-pid-issuer.entrypoints=websecure"
+      - "traefik.http.routers.well-known-pid-issuer.tls=true"
+      - "traefik.http.routers.well-known-pid-issuer.service=pid-issuer"
+      - "traefik.http.routers.well-known-pid-issuer.middlewares=well-known-pid-issuer-replace-path"
+      - "traefik.http.middlewares.well-known-pid-issuer-replace-path.replacepathregex.regex=^/.well-known/([a-zA-Z-]+)/pid-issuer$"
+      - "traefik.http.middlewares.well-known-pid-issuer-replace-path.replacepathregex.replacement=/pid-issuer/.well-known/$1"
       - "traefik.http.services.pid-issuer.loadbalancer.server.port=8080"
     networks:
       - wallet-ecosystem-network

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -306,6 +306,7 @@ services:
     volumes:
       - ./config/common/Healthcheck.class:/opt/Healthcheck.class:ro
     environment:
+      SERVER_SERVLET_CONTEXT_PATH: "/wallet-client-gateway"
       SPRING_PROFILES_ACTIVE: "prod"
       TZ: "Europe/Stockholm"
       JAVA_OPTS: "-Djava.net.preferIPv4Stack=true"
@@ -332,14 +333,14 @@ services:
           "--class-path",
           "/opt",
           "Healthcheck",
-          "http://localhost:8080/actuator/health",
+          "http://localhost:8080/wallet-client-gateway/actuator/health",
         ]
       start_period: 5s
       interval: 5s
       retries: 5
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.wallet-client-gateway.rule=Host(`wallet-client-gateway.wallet.local`)"
+      - "traefik.http.routers.wallet-client-gateway.rule=PathPrefix(`/wallet-client-gateway`)"
       - "traefik.http.routers.wallet-client-gateway.entrypoints=websecure"
       - "traefik.http.routers.wallet-client-gateway.tls=true"
       - "traefik.http.routers.wallet-client-gateway.service=wallet-client-gateway"
@@ -426,4 +427,3 @@ services:
         aliases:
           - refimpl-verifier.wallet.local
           - wallet-attribute-attestation-db.wallet.local
-          - wallet-client-gateway.wallet.local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -126,9 +126,9 @@ services:
       - SPRING_SECURITY_OAUTH2_RESOURCESERVER_OPAQUETOKEN_CLIENT_SECRET=zIKAV9DIIIaJCzHCVBPlySgU8KgY68U2
       - SERVER_FORWARD_HEADERS_STRATEGY=FRAMEWORK
       - ISSUER_PUBLICURL=https://localhost/pid-issuer
-      - ISSUER_AUTHORIZATIONSERVER_PUBLICURL=https://localhost/keycloak/idp/realms/pid-issuer-realm
-      - ISSUER_AUTHORIZATIONSERVER_METADATA=https://keycloak:8443/keycloak/idp/realms/pid-issuer-realm/.well-known/openid-configuration
-      - ISSUER_AUTHORIZATIONSERVER_INTROSPECTION=https://keycloak:8443/keycloak/idp/realms/pid-issuer-realm/protocol/openid-connect/token/introspect
+      - ISSUER_AUTHORIZATIONSERVER_PUBLICURL=https://localhost/idp/realms/pid-issuer-realm
+      - ISSUER_AUTHORIZATIONSERVER_METADATA=https://keycloak:8443/idp/realms/pid-issuer-realm/.well-known/openid-configuration
+      - ISSUER_AUTHORIZATIONSERVER_INTROSPECTION=https://keycloak:8443/idp/realms/pid-issuer-realm/protocol/openid-connect/token/introspect
       - ISSUER_CREDENTIALRESPONSEENCRYPTION_SUPPORTED=true
       - ISSUER_CREDENTIALRESPONSEENCRYPTION_REQUIRED=true
       - ISSUER_CREDENTIALRESPONSEENCRYPTION_ALGORITHMSSUPPORTED=ECDH-ES
@@ -147,7 +147,7 @@ services:
       - ISSUER_MDL_NOTIFICATIONS_ENABLED=true
       - ISSUER_CREDENTIALOFFER_URI=openid-credential-offer://
       - ISSUER_SIGNING_KEY=GenerateRandom
-      - ISSUER_KEYCLOAK_SERVER_URL=https://keycloak:8443/keycloak/idp
+      - ISSUER_KEYCLOAK_SERVER_URL=https://keycloak:8443/idp
       - ISSUER_KEYCLOAK_AUTHENTICATION_REALM=master
       - ISSUER_KEYCLOAK_CLIENT_ID=admin-cli
       - ISSUER_KEYCLOAK_USERNAME=admin
@@ -348,8 +348,8 @@ services:
     environment:
       - KC_PROXY_HEADERS=xforwarded
       - KC_HTTP_ENABLED=true
-      - KC_HTTP_RELATIVE_PATH=/keycloak/idp
-      - KC_HOSTNAME=https://localhost/keycloak/idp
+      - KC_HTTP_RELATIVE_PATH=/idp
+      - KC_HOSTNAME=https://localhost/idp
       - KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true
       - KC_HTTPS_CERTIFICATE_FILE=/etc/ssl/certs/keycloak.tls.crt
       - KC_HTTPS_CERTIFICATE_KEY_FILE=/etc/ssl/certs/keycloak.tls.key
@@ -368,14 +368,14 @@ services:
       - ./config/keycloak/certs/:/etc/ssl/certs/
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.keycloak.rule=PathPrefix(`/keycloak`)"
+      - "traefik.http.routers.keycloak.rule=PathPrefix(`/idp`)"
       - "traefik.http.routers.keycloak.entrypoints=websecure"
       - "traefik.http.routers.keycloak.tls=true"
       - "traefik.http.routers.keycloak.service=keycloak"
       - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
       - "traefik.http.routers.keycloak.middlewares=keycloak-replace-path"
       - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.regex=^/keycloak/.well-known/([a-zA-Z-]+)/idp/realms/([a-zA-Z-]+)/?"
-      - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.replacement=/keycloak/idp/realms/$2/.well-known/$1"
+      - "traefik.http.middlewares.keycloak-replace-path.replacepathregex.replacement=/idp/realms/$2/.well-known/$1"
     networks:
       - wallet-ecosystem-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -405,6 +405,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./config/traefik:/etc/traefik
     command:
+      - "--ping"
       - "--api.dashboard=true"
       - "--api.insecure=true"
       - "--providers.docker=true"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -421,7 +421,6 @@ services:
       - "traefik.http.routers.dashboard-secure.entrypoints=websecure"
       - "traefik.http.routers.dashboard-secure.tls=true"
       - "traefik.http.routers.dashboard-secure.service=api@internal"
-      - "traefik.http.routers.dashboard-secure.rule=Host(`traefik.wallet.local`)"
     networks:
       wallet-ecosystem-network:
         aliases:

--- a/src/test/java/se/digg/wallet/ecosystem/CustomVerifierTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/CustomVerifierTest.java
@@ -15,7 +15,7 @@ public class CustomVerifierTest {
   void isHealthy() {
     given()
         .when()
-        .get("https://custom-verifier.wallet.local")
+        .get("https://localhost/custom-verifier")
         .then()
         .assertThat().statusCode(200)
         .and().body(containsString("Strumpsorteringscentralen"));

--- a/src/test/java/se/digg/wallet/ecosystem/CustomVerifierTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/CustomVerifierTest.java
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
+
+import org.junit.jupiter.api.Test;
+
+public class CustomVerifierTest {
+
+  @Test
+  void isHealthy() {
+    given()
+        .when()
+        .get("https://custom-verifier.wallet.local")
+        .then()
+        .assertThat().statusCode(200)
+        .and().body(containsString("Strumpsorteringscentralen"));
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -51,7 +51,7 @@ public class EndToEndTest {
   public static final String TOKEN_ENDPOINT = PID_ISSUER_REALM + "/protocol/openid-connect/token";
   public static final String PID_ISSUER_BASE = "https://pid-issuer.wallet.local";
   private static final String WALLET_PROVIDER_WUA_URL =
-      "https://wallet-provider.wallet.local/wallet-unit-attestation";
+      "https://localhost/wallet-provider/wallet-unit-attestation";
   private static final String PID_ISSUER_CREDENTIAL_URL =
       PID_ISSUER_BASE + "/wallet/credentialEndpoint";
   private static final String PID_ISSUER_NONCE_URL = PID_ISSUER_BASE + "/wallet/nonceEndpoint";

--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 public class EndToEndTest {
 
   public static final String PID_ISSUER_REALM =
-      "https://localhost/keycloak/idp/realms/pid-issuer-realm";
+      "https://localhost/idp/realms/pid-issuer-realm";
   public static final String TOKEN_ENDPOINT = PID_ISSUER_REALM + "/protocol/openid-connect/token";
   public static final String PID_ISSUER_BASE = "https://localhost/pid-issuer";
   private static final String WALLET_PROVIDER_WUA_URL =

--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -49,7 +49,7 @@ public class EndToEndTest {
   public static final String PID_ISSUER_REALM =
       "https://keycloak.wallet.local/idp/realms/pid-issuer-realm";
   public static final String TOKEN_ENDPOINT = PID_ISSUER_REALM + "/protocol/openid-connect/token";
-  public static final String PID_ISSUER_BASE = "https://pid-issuer.wallet.local";
+  public static final String PID_ISSUER_BASE = "https://localhost/pid-issuer";
   private static final String WALLET_PROVIDER_WUA_URL =
       "https://localhost/wallet-provider/wallet-unit-attestation";
   private static final String PID_ISSUER_CREDENTIAL_URL =

--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 public class EndToEndTest {
 
   public static final String PID_ISSUER_REALM =
-      "https://keycloak.wallet.local/idp/realms/pid-issuer-realm";
+      "https://localhost/keycloak/idp/realms/pid-issuer-realm";
   public static final String TOKEN_ENDPOINT = PID_ISSUER_REALM + "/protocol/openid-connect/token";
   public static final String PID_ISSUER_BASE = "https://localhost/pid-issuer";
   private static final String WALLET_PROVIDER_WUA_URL =

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 public class KeycloakTest {
 
   public static final String PID_ISSUER_REALM =
-      "https://keycloak.wallet.local/idp/realms/pid-issuer-realm";
+      "https://localhost/keycloak/idp/realms/pid-issuer-realm";
   public static final String TOKEN_ENDPOINT = PID_ISSUER_REALM + "/protocol/openid-connect/token";
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 public class KeycloakTest {
 
   public static final String PID_ISSUER_REALM =
-      "https://localhost/keycloak/idp/realms/pid-issuer-realm";
+      "https://localhost/idp/realms/pid-issuer-realm";
   public static final String TOKEN_ENDPOINT = PID_ISSUER_REALM + "/protocol/openid-connect/token";
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -75,4 +75,14 @@ public class KeycloakTest {
         .body("access_token", notNullValue())
         .body("token_type", equalTo("DPoP"));
   }
+
+  @Test
+  void isAccessibleOnAlternateUrl() {
+    given()
+        .when()
+        .get("https://localhost/.well-known/oauth-authorization-server/idp/realms/pid-issuer-realm")
+        .then()
+        .assertThat().statusCode(200)
+        .and().body("issuer", equalTo("https://localhost/idp/realms/pid-issuer-realm"));
+  }
 }

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 public class PidIssuerTest {
   public static final String TOKEN_ENDPOINT =
-      "https://localhost/keycloak/idp/realms/pid-issuer-realm/protocol/openid-connect/token";
+      "https://localhost/idp/realms/pid-issuer-realm/protocol/openid-connect/token";
   private static final String PID_ISSUER_NONCE_URL =
       "https://localhost/pid-issuer/wallet/nonceEndpoint";
 
@@ -32,7 +32,7 @@ public class PidIssuerTest {
         .and()
         .body(
             "authorization_servers",
-            hasItem("https://localhost/keycloak/idp/realms/pid-issuer-realm"));
+            hasItem("https://localhost/idp/realms/pid-issuer-realm"));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -19,13 +19,13 @@ public class PidIssuerTest {
   public static final String TOKEN_ENDPOINT =
       "https://keycloak.wallet.local/idp/realms/pid-issuer-realm/protocol/openid-connect/token";
   private static final String PID_ISSUER_NONCE_URL =
-      "https://pid-issuer.wallet.local/wallet/nonceEndpoint";
+      "https://localhost/pid-issuer/wallet/nonceEndpoint";
 
   @Test
   void isHealthy() {
     given()
         .when()
-        .get("https://pid-issuer.wallet.local/.well-known/openid-credential-issuer")
+        .get("https://localhost/pid-issuer/.well-known/openid-credential-issuer")
         .then()
         .assertThat()
         .statusCode(200)

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -4,8 +4,11 @@
 
 package se.digg.wallet.ecosystem;
 
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
@@ -14,6 +17,8 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class PidIssuerTest {
   public static final String TOKEN_ENDPOINT =
@@ -21,18 +26,37 @@ public class PidIssuerTest {
   private static final String PID_ISSUER_NONCE_URL =
       "https://localhost/pid-issuer/wallet/nonceEndpoint";
 
-  @Test
-  void isHealthy() {
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "https://localhost/pid-issuer/.well-known/openid-credential-issuer",
+      "https://localhost/.well-known/openid-credential-issuer/pid-issuer"
+  })
+  void servesOpenIdCredentialIssuerMetadata(String url) {
     given()
         .when()
-        .get("https://localhost/pid-issuer/.well-known/openid-credential-issuer")
+        .get(url)
         .then()
-        .assertThat()
-        .statusCode(200)
-        .and()
-        .body(
+        .assertThat().statusCode(200)
+        .and().body(
+            "credential_issuer",
+            is("https://localhost/pid-issuer"))
+        .and().body(
+            "credential_request_encryption.jwks.keys",
+            not(empty()))
+        .and().body(
             "authorization_servers",
             hasItem("https://localhost/idp/realms/pid-issuer-realm"));
+  }
+
+  @Test
+  void servesJwtVcIssuerMetadata() {
+    given()
+        .when()
+        .get("https://localhost/.well-known/jwt-vc-issuer/pid-issuer")
+        .then()
+        .assertThat().statusCode(200)
+        .and().body("issuer", is("https://localhost/pid-issuer"))
+        .and().body("jwks.keys", not(empty()));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 public class PidIssuerTest {
   public static final String TOKEN_ENDPOINT =
-      "https://keycloak.wallet.local/idp/realms/pid-issuer-realm/protocol/openid-connect/token";
+      "https://localhost/keycloak/idp/realms/pid-issuer-realm/protocol/openid-connect/token";
   private static final String PID_ISSUER_NONCE_URL =
       "https://localhost/pid-issuer/wallet/nonceEndpoint";
 
@@ -32,7 +32,7 @@ public class PidIssuerTest {
         .and()
         .body(
             "authorization_servers",
-            hasItem("https://keycloak.wallet.local/idp/realms/pid-issuer-realm"));
+            hasItem("https://localhost/keycloak/idp/realms/pid-issuer-realm"));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierBackendTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierBackendTest.java
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.hamcrest.CoreMatchers.is;
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
+
+import org.junit.jupiter.api.Test;
+
+public class ReferenceVerifierBackendTest {
+
+  @Test
+  void isHealthy() {
+    given()
+        .when()
+        .get("https://refimpl-verifier-backend.wallet.local/actuator/health")
+        .then()
+        .assertThat().statusCode(200)
+        .and().body("status", is("UP"));
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierBackendTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierBackendTest.java
@@ -15,7 +15,7 @@ public class ReferenceVerifierBackendTest {
   void isHealthy() {
     given()
         .when()
-        .get("https://refimpl-verifier-backend.wallet.local/actuator/health")
+        .get("https://localhost/refimpl-verifier-backend/actuator/health")
         .then()
         .assertThat().statusCode(200)
         .and().body("status", is("UP"));

--- a/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierFrontendTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierFrontendTest.java
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.hamcrest.CoreMatchers.is;
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
+
+import org.junit.jupiter.api.Test;
+
+public class ReferenceVerifierFrontendTest {
+
+  @Test
+  void isHealthy() {
+    given()
+        .when()
+        .get("https://refimpl-verifier.wallet.local")
+        .then()
+        .assertThat().statusCode(200)
+        .and().body("html.head.title", is("VerifierUi"));
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierFrontendTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/ReferenceVerifierFrontendTest.java
@@ -8,7 +8,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
+@DisabledIfEnvironmentVariable(
+    named = "DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_USING_CUSTOM_HOSTS",
+    matches = "true")
 public class ReferenceVerifierFrontendTest {
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
@@ -16,7 +16,7 @@ public class TraefikTest {
   void respondsToPing() {
     given()
         .when()
-        .get("http://traefik.wallet.local:8080/ping")
+        .get("http://localhost:8080/ping")
         .then()
         .assertThat().statusCode(200)
         .and().body(is("OK"));
@@ -26,7 +26,7 @@ public class TraefikTest {
   void isHealthy() {
     given()
         .when()
-        .get("https://traefik.wallet.local")
+        .get("http://localhost:8080/dashboard")
         .then()
         .assertThat().statusCode(200)
         .and().body("html.head.title", is("Traefik"))

--- a/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
+
+import org.junit.jupiter.api.Test;
+
+public class TraefikTest {
+
+  @Test
+  void isHealthy() {
+    given()
+        .when()
+        .get("https://traefik.wallet.local")
+        .then()
+        .assertThat().statusCode(200)
+        .and().body("html.head.title", is("Traefik"))
+        .and().body(containsString("<div id=q-app>"));
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
@@ -13,6 +13,16 @@ import org.junit.jupiter.api.Test;
 public class TraefikTest {
 
   @Test
+  void respondsToPing() {
+    given()
+        .when()
+        .get("http://traefik.wallet.local:8080/ping")
+        .then()
+        .assertThat().statusCode(200)
+        .and().body(is("OK"));
+  }
+
+  @Test
   void isHealthy() {
     given()
         .when()

--- a/src/test/java/se/digg/wallet/ecosystem/WalletAccountTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletAccountTest.java
@@ -15,7 +15,7 @@ public class WalletAccountTest {
   void isHealthy() {
     given()
         .when()
-        .get("https://wallet-account.wallet.local/actuator/health")
+        .get("https://localhost/wallet-account/actuator/health")
         .then()
         .assertThat().statusCode(200)
         .and().body("status", equalTo("UP"));

--- a/src/test/java/se/digg/wallet/ecosystem/WalletAttributeAttestationTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletAttributeAttestationTest.java
@@ -17,7 +17,7 @@ public class WalletAttributeAttestationTest {
   void isHealthy() {
     given()
         .when()
-        .get("https://wallet-attribute-attestation.wallet.local/actuator/health")
+        .get("https://localhost/wallet-attribute-attestation/actuator/health")
         .then()
         .assertThat().statusCode(200)
         .and().body("status", equalTo("UP"));
@@ -32,7 +32,7 @@ public class WalletAttributeAttestationTest {
           "wuaId": "790acda4-3dec-4d93-8efe-71375109d30e",
           "attestationData": "string"
         }""")
-        .post("https://wallet-attribute-attestation.wallet.local/attestation")
+        .post("https://localhost/wallet-attribute-attestation/attestation")
         .then()
         .assertThat().statusCode(201).and()
         .extract()
@@ -45,7 +45,7 @@ public class WalletAttributeAttestationTest {
     given()
         .when()
         .get(
-            "https://wallet-attribute-attestation.wallet.local/attestation/%s".formatted(createdId))
+            "https://localhost/wallet-attribute-attestation/attestation/%s".formatted(createdId))
         .then()
         .assertThat().statusCode(200)
         .and().body("hsmId", equalTo("cbe80ad0-6a7d-4a5a-9891-8b4e95fa4d49"));

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -18,7 +18,7 @@ public class WalletClientGatewayTest {
   void isHealthy() {
     given()
         .when()
-        .get("https://wallet-client-gateway.wallet.local/actuator/health")
+        .get("https://localhost/wallet-client-gateway/actuator/health")
         .then()
         .assertThat().statusCode(200)
         .and().body("status", equalTo("UP"));
@@ -34,7 +34,7 @@ public class WalletClientGatewayTest {
           "attestationData": "string"
         }""")
         .header("X-API-KEY", "apikey")
-        .post("https://wallet-client-gateway.wallet.local/attribute-attestations")
+        .post("https://localhost/wallet-client-gateway/attribute-attestations")
         .then()
         .assertThat().statusCode(201).and()
         .extract()
@@ -48,7 +48,7 @@ public class WalletClientGatewayTest {
         .when()
         .header("X-API-KEY", "apikey")
         .get(
-            "https://wallet-client-gateway.wallet.local/attribute-attestations/%s"
+            "https://localhost/wallet-client-gateway/attribute-attestations/%s"
                 .formatted(createdId))
         .then()
         .assertThat().statusCode(200)
@@ -71,7 +71,7 @@ public class WalletClientGatewayTest {
               }
             }""")
         .header("X-API-KEY", "apikey")
-        .post("https://wallet-client-gateway.wallet.local/wua")
+        .post("https://localhost/wallet-client-gateway/wua")
         .then()
         .assertThat().statusCode(201).and()
         .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
@@ -21,7 +21,7 @@ public class WalletProviderTest {
   void isHealthy() {
     given()
         .when()
-        .get("https://wallet-provider.wallet.local/actuator/health")
+        .get("https://localhost/wallet-provider/actuator/health")
         .then()
         .assertThat().statusCode(200)
         .and().body("status", equalTo("UP"));
@@ -37,7 +37,7 @@ public class WalletProviderTest {
             UUID.randomUUID(),
             new ObjectMapper().writeValueAsString(
                 new ECKeyGenerator(Curve.P_256).generate().toPublicJWK().toJSONString())))
-        .post("https://wallet-provider.wallet.local/wallet-unit-attestation")
+        .post("https://localhost/wallet-provider/wallet-unit-attestation")
         .then()
         .assertThat().statusCode(200).and().body(matchesPattern(
             "^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));


### PR DESCRIPTION
Here we change our Traefik configuration to expose our services on different paths on localhost instead of having a specific host name for each service. The main benefit is to allow using the wallet ecosystem on a machine where it is not easy to modify the hosts mapping. For instance, if the user is not allowed to edit the hosts file.

Note: The reference verifier does not seem to support running on a specific path and consequently has not been migrated.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
