### PR TITLE
Refactor/extract test clients

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.ECKey;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.net.URI;
+import java.util.Map;
+
+public class KeycloakClient {
+
+  private final URI base;
+
+  public KeycloakClient() {
+    this(URI.create("https://localhost/idp/"));
+  }
+
+  public KeycloakClient(URI base) {
+    this.base = base;
+  }
+
+  public String getDpopAccessToken(
+      String realm, ECKey key, Map<String, String> parameters) throws JOSEException {
+
+    URI tokenEndpoint = base.resolve("realms/" + realm + "/protocol/openid-connect/token");
+    String dpopProof = DpopUtil.createDpopProof(key, tokenEndpoint.toString(), "POST");
+
+    return given()
+        .when()
+        .contentType(ContentType.URLENC)
+        .header("DPoP", dpopProof)
+        .formParams(parameters)
+        .post(tokenEndpoint)
+        .then()
+        .assertThat()
+        .statusCode(200)
+        .and()
+        .body("access_token", notNullValue())
+        .body("token_type", org.hamcrest.CoreMatchers.equalTo("DPoP"))
+        .extract()
+        .path("access_token");
+  }
+
+  public Response tryGetHealth(String path) {
+    return given().when().get(base.resolve("health/" + path));
+  }
+
+  public Response tryGetRealm(String name) {
+    return given().when().get(base.resolve("realms/" + name));
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
+
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.ECDHEncrypter;
+import com.nimbusds.jose.crypto.factories.DefaultJWEDecrypterFactory;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jwt.EncryptedJWT;
+import io.restassured.path.json.JsonPath;
+import java.net.URI;
+import java.security.interfaces.ECPrivateKey;
+import java.text.ParseException;
+import java.util.Map;
+
+public class PidIssuerClient {
+
+  private final String name;
+  private final URI base;
+
+  public PidIssuerClient() {
+    name = "https://localhost/pid-issuer";
+    base = URI.create(name + "/");
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getNonce(String accessToken, ECKey key) throws JOSEException {
+    URI nonceEndpoint = this.base.resolve("wallet/nonceEndpoint");
+    return given()
+        .auth()
+        .oauth2(accessToken)
+        .header("DPoP",
+            DpopUtil.createDpopProof(key, nonceEndpoint.toString(), "POST"))
+        .when()
+        .post(nonceEndpoint)
+        .then()
+        .assertThat()
+        .statusCode(200)
+        .extract()
+        .path("c_nonce");
+  }
+
+  public ECKey getCredentialRequestEncryptionKey() throws ParseException {
+    String issuerMetadata =
+        given()
+            .when()
+            .get(this.base.resolve(".well-known/openid-credential-issuer"))
+            .then().statusCode(200).extract().asString();
+
+    JsonPath metadataPath = new JsonPath(issuerMetadata);
+    Map<String, Object> jwksMap = metadataPath.getMap("credential_request_encryption.jwks");
+    JWKSet jwkSet = JWKSet.parse(jwksMap);
+
+    return (ECKey) jwkSet.getKeys().getFirst();
+  }
+
+  public Payload issueCredentials(String accessToken, ECKey userJwk, ECKey jwk, String proof,
+      ECKey pidIssuerCredentialRequestEncryptionKey) throws JOSEException, ParseException {
+    return decryptPayload(
+        postCredentials(
+            accessToken, userJwk, encryptPayload(
+                String.format("""
+                    {
+                      "format": "vc+sd-jwt",
+                      "proofs": { "jwt": ["%s"] },
+                      "credential_configuration_id": "eu.europa.ec.eudi.pid_vc_sd_jwt",
+                      "credential_response_encryption": {
+                        "jwk": %s,
+                        "enc": "A128GCM",
+                        "zip": "DEF"
+                      }
+                    }""",
+                    proof, jwk.toPublicJWK().toJSONString()),
+                pidIssuerCredentialRequestEncryptionKey)),
+        jwk.toECPrivateKey());
+  }
+
+  private String postCredentials(
+      String accessToken, ECKey userJwk, String requestPayload) throws JOSEException {
+    String credentialsEndpoint =
+        this.base.resolve("wallet/credentialEndpoint").toString();
+    String responsePayload =
+        given()
+            .auth()
+            .oauth2(accessToken)
+            .header("DPoP", DpopUtil.createDpopProof(userJwk,
+                credentialsEndpoint, "POST"))
+            .when()
+            .contentType("application/jwt")
+            .body(requestPayload)
+            .post(credentialsEndpoint)
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+    assertNotNull(responsePayload);
+
+    return responsePayload;
+  }
+
+  private String encryptPayload(String payload, JWK publicKey) throws JOSEException {
+    JWEObject jweObject =
+        new JWEObject(new JWEHeader.Builder(JWEAlgorithm.ECDH_ES, EncryptionMethod.A128GCM)
+            .keyID(publicKey.getKeyID())
+            .jwk(publicKey.toPublicJWK())
+            .type(JOSEObjectType.JWT)
+            .build(), new Payload(payload));
+
+    jweObject.encrypt(new ECDHEncrypter(publicKey.toECKey()));
+
+    return jweObject.serialize();
+  }
+
+  private static Payload decryptPayload(String payload, ECPrivateKey privateKey)
+      throws ParseException, JOSEException {
+
+    EncryptedJWT encryptedJwt = EncryptedJWT.parse(payload);
+    encryptedJwt.decrypt(
+        new DefaultJWEDecrypterFactory()
+            .createJWEDecrypter(encryptedJwt.getHeader(), privateKey));
+
+    return encryptedJwt.getPayload();
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -130,7 +130,7 @@ public class PidIssuerClient {
     return jweObject.serialize();
   }
 
-  private static Payload decryptPayload(String payload, ECPrivateKey privateKey)
+  private Payload decryptPayload(String payload, ECPrivateKey privateKey)
       throws ParseException, JOSEException {
 
     EncryptedJWT encryptedJwt = EncryptedJWT.parse(payload);

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
@@ -10,11 +10,19 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.jwk.ECKey;
 import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import java.net.URI;
 import java.util.UUID;
 
 public class WalletProviderClient {
-  private static final String WALLET_PROVIDER_WUA_URL =
-      "https://localhost/wallet-provider/wallet-unit-attestation";
+
+  private final URI base = URI.create("https://localhost/wallet-provider/");
+
+  public Response tryGetHealth() {
+    return given()
+        .when()
+        .get(base.resolve("actuator/health"));
+  }
 
   public String getWalletUnitAttestation(ECKey jwk) throws JsonProcessingException {
     return given()
@@ -25,7 +33,7 @@ public class WalletProviderClient {
                 { "walletId": "%s", "jwk": %s }""",
                 UUID.randomUUID(),
                 new ObjectMapper().writeValueAsString(jwk.toPublicJWK().toJSONString())))
-        .post(WALLET_PROVIDER_WUA_URL)
+        .post(base.resolve("wallet-unit-attestation"))
         .then()
         .assertThat()
         .statusCode(200)

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.jwk.ECKey;
+import io.restassured.http.ContentType;
+import java.util.UUID;
+
+public class WalletProviderClient {
+  private static final String WALLET_PROVIDER_WUA_URL =
+      "https://localhost/wallet-provider/wallet-unit-attestation";
+
+  public String getWalletUnitAttestation(ECKey jwk) throws JsonProcessingException {
+    return given()
+        .when()
+        .contentType(ContentType.JSON)
+        .body(
+            String.format("""
+                { "walletId": "%s", "jwk": %s }""",
+                UUID.randomUUID(),
+                new ObjectMapper().writeValueAsString(jwk.toPublicJWK().toJSONString())))
+        .post(WALLET_PROVIDER_WUA_URL)
+        .then()
+        .assertThat()
+        .statusCode(200)
+        .extract()
+        .body()
+        .asString();
+  }
+}


### PR DESCRIPTION
Here we extract client for interacting with Keycloak, the Wallet Provider and the PID issuer. This makes the test code easier the read and understand. This will also hides the details of the service URLs from the tests so that we can more easily add support for running the test suite against different environments.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
