### PR TITLE
Feat/allow end to end test on alternate hosts

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -83,7 +83,9 @@ docker-compose up -d
 mvn test
 ```
 
-**Note:** Some of our services uses a custom host mapping,
+#### Skipping tests using custom hosts
+
+Some of our services uses a custom host mapping,
 e.g. `refimpl-verifier.wallet.local`.
 On machines where the user cannot change the hosts mapping
 the automated tests that try to use a service using such a host name will fail.
@@ -93,6 +95,28 @@ and run the test suite like so:
 
 ```shell
 env DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_USING_CUSTOM_HOSTS=true mvn test
+```
+
+#### Running tests on alternate hosts
+
+Normally the tests suite runs against the wallet ecosystem deployed locally.
+In order to run the tests on alternate hosts,
+you can configure the location of those hosts using environment variables like so:
+
+```shell
+env DIGG_WALLET_ECOSYSTEM_WALLET_PROVIDER_BASE_URI=https://wallet-provider.example.com \
+    DIGG_WALLET_ECOSYSTEM_PID_ISSUER_BASE_URI=https://pid-issuer.example.com \
+    DIGG_WALLET_ECOSYSTEM_KEYCLOAK_BASE_URI=https://keycloak.example.com \
+    mvn test
+```
+
+#### Skipping Keycloak health tests
+
+Under some configurations the Keycloak health endpoints are not exposed.
+In order to avoid test failures in those situations, you can skip those tests like so:
+
+```shell
+env DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_KEYCLOAK_HEALTH=true mvn test
 ```
 
 ### Pull Request Workflow

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
@@ -13,13 +13,16 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 
 public class KeycloakClient {
 
   private final URI base;
 
   public KeycloakClient() {
-    this(URI.create("https://localhost/idp/"));
+    this(URI.create(
+        Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_KEYCLOAK_BASE_URI"))
+            .orElse("https://localhost/idp") + "/"));
   }
 
   public KeycloakClient(URI base) {

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -14,6 +14,7 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import java.net.URI;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -23,6 +24,9 @@ public class KeycloakTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"live", "ready", "started", ""})
+  @DisabledIfEnvironmentVariable(
+      named = "DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_KEYCLOAK_HEALTH",
+      matches = "true")
   void isHealthy(String path) {
     keycloak.tryGetHealth(path)
         .then()

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.security.interfaces.ECPrivateKey;
 import java.text.ParseException;
 import java.util.Map;
+import java.util.Optional;
 
 public class PidIssuerClient {
 
@@ -32,7 +33,8 @@ public class PidIssuerClient {
   private final URI base;
 
   public PidIssuerClient() {
-    name = "https://localhost/pid-issuer";
+    name = Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_PID_ISSUER_BASE_URI"))
+        .orElse("https://localhost/pid-issuer");
     base = URI.create(name + "/");
   }
 

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
@@ -12,11 +12,14 @@ import com.nimbusds.jose.jwk.ECKey;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.net.URI;
+import java.util.Optional;
 import java.util.UUID;
 
 public class WalletProviderClient {
 
-  private final URI base = URI.create("https://localhost/wallet-provider/");
+  private final URI base = URI.create(
+      Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_WALLET_PROVIDER_BASE_URI"))
+          .orElse("https://localhost/wallet-provider") + "/");
 
   public Response tryGetHealth() {
     return given()


### PR DESCRIPTION
To run the test end-to-end test on alternate hosts, you can use the
 command below:

	env DIGG_WALLET_ECOSYSTEM_WALLET_PROVIDER_BASE_URI=https://wallet-provider.example.com/ \
		DIGG_WALLET_ECOSYSTEM_PID_ISSUER_BASE_URI=https://pid-issuer.example.com/ \
		DIGG_WALLET_ECOSYSTEM_KEYCLOAK_BASE_URI=https://keycloak.example.com/ \
		mvn test

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
