### PR TITLE
Test/pid issuer links

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -69,7 +69,7 @@ public class EndToEndTest {
     Map<String, Object> payloadJson = pidIssuer.issueCredentials(
         accessToken, userJwk, jwk, proof, pidIssuerCredentialRequestEncryptionKey).toJSONObject();
 
-    assertEquals(pidIssuer.getIdentifier().toString(), payloadJson.get("iss"));
+    assertEquals(ServiceIdentifier.PID_ISSUER.toString(), payloadJson.get("iss"));
 
     var credentials = payloadJson.get("credentials");
     assertThat(credentials, instanceOf(List.class));
@@ -86,7 +86,7 @@ public class EndToEndTest {
     JWTClaimsSet claims =
         new JWTClaimsSet.Builder()
             .issuer(jwk.toPublicJWK().toString())
-            .audience(pidIssuer.getIdentifier().toString())
+            .audience(ServiceIdentifier.PID_ISSUER.toString())
             .issueTime(Date.from(Instant.now()))
             .claim("nonce", nonce)
             .claim("wua", wua)

--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -69,7 +69,7 @@ public class EndToEndTest {
     Map<String, Object> payloadJson = pidIssuer.issueCredentials(
         accessToken, userJwk, jwk, proof, pidIssuerCredentialRequestEncryptionKey).toJSONObject();
 
-    assertEquals(pidIssuer.getName(), payloadJson.get("iss"));
+    assertEquals(pidIssuer.getIdentifier().toString(), payloadJson.get("iss"));
 
     var credentials = payloadJson.get("credentials");
     assertThat(credentials, instanceOf(List.class));
@@ -86,7 +86,7 @@ public class EndToEndTest {
     JWTClaimsSet claims =
         new JWTClaimsSet.Builder()
             .issuer(jwk.toPublicJWK().toString())
-            .audience(pidIssuer.getName())
+            .audience(pidIssuer.getIdentifier().toString())
             .issueTime(Date.from(Instant.now()))
             .claim("nonce", nonce)
             .claim("wua", wua)

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
@@ -13,16 +13,13 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.net.URI;
 import java.util.Map;
-import java.util.Optional;
 
 public class KeycloakClient {
 
   private final URI base;
 
   public KeycloakClient() {
-    this(URI.create(
-        Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_KEYCLOAK_BASE_URI"))
-            .orElse("https://localhost/idp") + "/"));
+    this(ServiceIdentifier.KEYCLOAK.getResourceRoot());
   }
 
   public KeycloakClient(URI base) {

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -6,6 +6,7 @@ package se.digg.wallet.ecosystem;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
@@ -13,9 +14,12 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import java.net.URI;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class KeycloakTest {
@@ -67,12 +71,21 @@ public class KeycloakTest {
         "password", "password")));
   }
 
-  @Test
-  void isAccessibleOnAlternateUrl() {
-    new KeycloakClient(URI.create("https://localhost/.well-known/oauth-authorization-server/idp/"))
-        .tryGetRealm("pid-issuer-realm")
+  public static Stream<Arguments> pidIssuerRealmMetadataUrls() {
+    return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
+        s.toString(),
+        s.applyTo(ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve(
+            "realms/pid-issuer-realm"), "oauth-authorization-server")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("pidIssuerRealmMetadataUrls")
+  void servesMetadataForPidIssuerRealm(
+      String labelNotUsedInTestButIncludedInDisplayName, URI uri) {
+    given().when().get(uri)
         .then()
         .assertThat().statusCode(200)
-        .and().body("issuer", equalTo("https://localhost/idp/realms/pid-issuer-realm"));
+        .and().body("issuer", equalTo(ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve(
+            "realms/pid-issuer-realm").toString()));
   }
 }

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -86,6 +86,8 @@ public class KeycloakTest {
         .then()
         .assertThat().statusCode(200)
         .and().body("issuer", equalTo(ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve(
-            "realms/pid-issuer-realm").toString()));
+            "realms/pid-issuer-realm").toString()))
+        .and().body("token_endpoint", equalTo(ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve(
+            "realms/pid-issuer-realm/protocol/openid-connect/token").toString()));
   }
 }

--- a/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategy.java
+++ b/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategy.java
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public enum MetadataLocationStrategy {
+
+  /**
+   * This strategy locates the metadata as a descendant under the service root, e.g.
+   * <code>https://example.com/tenant/.well-known/metadata</code>
+   */
+  BASIC {
+    @Override
+    protected String getPath(String identifierPath, String metadataPath) {
+      return identifierPath + metadataPath;
+    }
+  },
+
+  /**
+   * This strategy locates the metadata under a well-known path directly under the service host and
+   * is compliant with the OpenID for Verifiable Credential Issuance specification, e.g.
+   * <code>https://example.com/.well-known/metadata/tenant</code>
+   *
+   * @see "https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.2"
+   */
+  OID4VCI_COMPLIANT {
+    @Override
+    protected String getPath(String identifierPath, String metadataPath) {
+      return metadataPath + identifierPath;
+    }
+  };
+
+  public final URI applyTo(URI identifier, String metadata) {
+    try {
+      return new URI(
+          identifier.getScheme(), identifier.getAuthority(),
+          getPath(identifier.getPath(), "/.well-known/" + metadata),
+          null, null);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected abstract String getPath(String identifierPath, String metadataPath);
+}

--- a/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategyTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategyTest.java
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static se.digg.wallet.ecosystem.MetadataLocationStrategy.BASIC;
+import static se.digg.wallet.ecosystem.MetadataLocationStrategy.OID4VCI_COMPLIANT;
+
+import java.net.URI;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MetadataLocationStrategyTest {
+
+  public static Stream<Arguments> uriExamples() {
+    return Stream.of(
+        Arguments.of(BASIC, "https://issuer.example.com/tenant",
+            "https://issuer.example.com/tenant/.well-known/openid-credential-issuer"),
+        Arguments.of(BASIC, "https://issuer.example.com",
+            "https://issuer.example.com/.well-known/openid-credential-issuer"),
+        Arguments.of(OID4VCI_COMPLIANT, "https://issuer.example.com/tenant",
+            "https://issuer.example.com/.well-known/openid-credential-issuer/tenant"),
+        Arguments.of(OID4VCI_COMPLIANT, "https://issuer.example.com",
+            "https://issuer.example.com/.well-known/openid-credential-issuer"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("uriExamples")
+  void producesExpectedUris(MetadataLocationStrategy strategy, URI identifier, URI expected) {
+    assertThat(strategy.applyTo(identifier, "openid-credential-issuer"), is(expected));
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -35,15 +35,9 @@ import org.jsoup.nodes.Element;
 public class PidIssuerClient {
 
   private final URI base;
-  private final URI identifier;
 
   public PidIssuerClient() {
     base = ServiceIdentifier.PID_ISSUER.getResourceRoot();
-    identifier = ServiceIdentifier.PID_ISSUER.toUri();
-  }
-
-  public URI getIdentifier() {
-    return identifier;
   }
 
   public Map<String, String> getUsefulLinks() {

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -21,7 +21,6 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.EncryptedJWT;
-import io.restassured.path.json.JsonPath;
 import io.restassured.response.ValidatableResponse;
 import java.net.URI;
 import java.security.interfaces.ECPrivateKey;
@@ -84,10 +83,9 @@ public class PidIssuerClient {
   }
 
   public ECKey getCredentialRequestEncryptionKey() throws ParseException {
-    String issuerMetadata = getCredentialIssuerMetadata().extract().asString();
+    Map<String, Object> jwksMap =
+        getCredentialIssuerMetadata().extract().path("credential_request_encryption.jwks");
 
-    JsonPath metadataPath = new JsonPath(issuerMetadata);
-    Map<String, Object> jwksMap = metadataPath.getMap("credential_request_encryption.jwks");
     JWKSet jwkSet = JWKSet.parse(jwksMap);
 
     return (ECKey) jwkSet.getKeys().getFirst();

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -44,6 +44,10 @@ public class PidIssuerClient {
     base = URI.create(name + "/");
   }
 
+  public URI getIdentifier() {
+    return URI.create(name);
+  }
+
   public String getName() {
     return name;
   }

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -27,7 +27,6 @@ import java.security.interfaces.ECPrivateKey;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jsoup.Jsoup;
@@ -39,11 +38,8 @@ public class PidIssuerClient {
   private final URI identifier;
 
   public PidIssuerClient() {
-    String baseUriWithoutFinalSlash =
-        Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_PID_ISSUER_BASE_URI"))
-        .orElse("https://localhost/pid-issuer");
-    base = URI.create(baseUriWithoutFinalSlash + "/");
-    identifier = URI.create(baseUriWithoutFinalSlash);
+    base = ServiceIdentifier.PID_ISSUER.getResourceRoot();
+    identifier = ServiceIdentifier.PID_ISSUER.toUri();
   }
 
   public URI getIdentifier() {

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -35,21 +35,19 @@ import org.jsoup.nodes.Element;
 
 public class PidIssuerClient {
 
-  private final String name;
   private final URI base;
+  private final URI identifier;
 
   public PidIssuerClient() {
-    name = Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_PID_ISSUER_BASE_URI"))
+    String baseUriWithoutFinalSlash =
+        Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_PID_ISSUER_BASE_URI"))
         .orElse("https://localhost/pid-issuer");
-    base = URI.create(name + "/");
+    base = URI.create(baseUriWithoutFinalSlash + "/");
+    identifier = URI.create(baseUriWithoutFinalSlash);
   }
 
   public URI getIdentifier() {
-    return URI.create(name);
-  }
-
-  public String getName() {
-    return name;
+    return identifier;
   }
 
   public Map<String, String> getUsefulLinks() {

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -16,7 +16,6 @@ import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -59,22 +58,10 @@ public class PidIssuerTest {
     given().when().get(link).then().assertThat().statusCode(200);
   }
 
-  public static Stream<Arguments> credentialIssuerMetadataUrls() throws URISyntaxException {
-    URI identifier = IDENTIFIER.toUri();
-
-    return Stream.of(
-        // This is the "raw" location under the PID issuer base path
-        Arguments.of("Basic", new URI(
-            identifier.getScheme(), identifier.getAuthority(),
-            identifier.getPath() + "/.well-known/openid-credential-issuer",
-            null, null)),
-
-        // This is the standard location according to the specification
-        // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.2
-        Arguments.of("OpenID4VCI compliant", new URI(
-            identifier.getScheme(), identifier.getAuthority(),
-            "/.well-known/openid-credential-issuer" + identifier.getPath(),
-            null, null)));
+  public static Stream<Arguments> credentialIssuerMetadataUrls() {
+    return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
+        s.toString(),
+        s.applyTo(IDENTIFIER.toUri(), "openid-credential-issuer")));
   }
 
   @ParameterizedTest
@@ -99,22 +86,10 @@ public class PidIssuerTest {
         .extract().path("authorization_servers");
   }
 
-  public static Stream<Arguments> jwtVcIssuerMetadataUrls() throws URISyntaxException {
-    URI identifier = IDENTIFIER.toUri();
-
-    return Stream.of(
-        // This is the "raw" location under the PID issuer base path
-        Arguments.of("Basic", new URI(
-            identifier.getScheme(), identifier.getAuthority(),
-            identifier.getPath() + "/.well-known/jwt-vc-issuer",
-            null, null)),
-
-        // This mimics the standard location of the credential issuer metadata
-        // https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.2
-        Arguments.of("OpenID4VCI compliant", new URI(
-            identifier.getScheme(), identifier.getAuthority(),
-            "/.well-known/jwt-vc-issuer" + identifier.getPath(),
-            null, null)));
+  public static Stream<Arguments> jwtVcIssuerMetadataUrls() {
+    return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
+        s.toString(),
+        s.applyTo(IDENTIFIER.toUri(), "jwt-vc-issuer")));
   }
 
   @ParameterizedTest

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -17,7 +17,6 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -45,8 +44,14 @@ public class PidIssuerTest {
         .map(entry -> Arguments.of(entry.getKey(), entry.getValue()));
   }
 
+  public static Stream<Arguments> authorizationServers() {
+    return new PidIssuerClient().getAuthorizationServers().stream()
+        .map(s -> Arguments.of("Authorization Server", s.toString()));
+  }
+
   @ParameterizedTest
   @MethodSource("usefulLinks")
+  @MethodSource("authorizationServers")
   void linkWorks(String labelNotUsedInTestButIncludedInDisplayName, String link) {
     given().when().get(link).then().assertThat().statusCode(200);
   }
@@ -74,7 +79,7 @@ public class PidIssuerTest {
   void servesCredentialIssuerMetadata(
       String labelNotUsedInTestButIncludedInDisplayName, URI uri) {
 
-    List<String> authorizationServers = given()
+    given()
         .when()
         .get(uri)
         .then()
@@ -89,12 +94,6 @@ public class PidIssuerTest {
             "authorization_servers",
             not(empty()))
         .extract().path("authorization_servers");
-
-    given()
-        .when()
-        .get(authorizationServers.getFirst())
-        .then()
-        .assertThat().statusCode(200);
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -4,6 +4,7 @@
 
 package se.digg.wallet.ecosystem;
 
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -82,8 +83,8 @@ public class PidIssuerTest {
             not(empty()))
         .and().body(
             "authorization_servers",
-            not(empty()))
-        .extract().path("authorization_servers");
+            hasItem(ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve(
+                "realms/pid-issuer-realm").toString()));
   }
 
   public static Stream<Arguments> jwtVcIssuerMetadataUrls() {

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -25,6 +25,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class PidIssuerTest {
+
+  private static final ServiceIdentifier IDENTIFIER = ServiceIdentifier.PID_ISSUER;
+
   private final PidIssuerClient pidIssuer = new PidIssuerClient();
   private final KeycloakClient keycloak = new KeycloakClient();
 
@@ -57,7 +60,7 @@ public class PidIssuerTest {
   }
 
   public static Stream<Arguments> credentialIssuerMetadataUrls() throws URISyntaxException {
-    URI identifier = new PidIssuerClient().getIdentifier();
+    URI identifier = IDENTIFIER.toUri();
 
     return Stream.of(
         // This is the "raw" location under the PID issuer base path
@@ -86,7 +89,7 @@ public class PidIssuerTest {
         .assertThat().statusCode(200)
         .and().body(
             "credential_issuer",
-            is(pidIssuer.getIdentifier().toString()))
+            is(IDENTIFIER.toString()))
         .and().body(
             "credential_request_encryption.jwks.keys",
             not(empty()))
@@ -97,7 +100,7 @@ public class PidIssuerTest {
   }
 
   public static Stream<Arguments> jwtVcIssuerMetadataUrls() throws URISyntaxException {
-    URI identifier = new PidIssuerClient().getIdentifier();
+    URI identifier = IDENTIFIER.toUri();
 
     return Stream.of(
         // This is the "raw" location under the PID issuer base path
@@ -124,7 +127,7 @@ public class PidIssuerTest {
         .get(uri)
         .then()
         .assertThat().statusCode(200)
-        .and().body("issuer", is(pidIssuer.getIdentifier().toString()))
+        .and().body("issuer", is(IDENTIFIER.toString()))
         .and().body("jwks.keys", not(empty()));
   }
 

--- a/src/test/java/se/digg/wallet/ecosystem/ServiceIdentifier.java
+++ b/src/test/java/se/digg/wallet/ecosystem/ServiceIdentifier.java
@@ -28,6 +28,11 @@ public enum ServiceIdentifier {
         .orElse(defaultUri);
   }
 
+  @Override
+  public String toString() {
+    return getValue();
+  }
+
   public URI toUri() {
     return URI.create(getValue());
   }

--- a/src/test/java/se/digg/wallet/ecosystem/ServiceIdentifier.java
+++ b/src/test/java/se/digg/wallet/ecosystem/ServiceIdentifier.java
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import java.net.URI;
+import java.util.Optional;
+
+public enum ServiceIdentifier {
+  KEYCLOAK("https://localhost/idp",
+      "DIGG_WALLET_ECOSYSTEM_KEYCLOAK_BASE_URI"),
+  PID_ISSUER("https://localhost/pid-issuer",
+      "DIGG_WALLET_ECOSYSTEM_PID_ISSUER_BASE_URI"),
+  WALLET_PROVIDER("https://localhost/wallet-provider",
+      "DIGG_WALLET_ECOSYSTEM_WALLET_PROVIDER_BASE_URI");
+
+  private final String defaultUri;
+  private final String environmentVariable;
+
+  ServiceIdentifier(String defaultUri, String environmentVariable) {
+    this.defaultUri = defaultUri;
+    this.environmentVariable = environmentVariable;
+  }
+
+  private String getValue() {
+    return Optional.ofNullable(System.getenv(environmentVariable))
+        .orElse(defaultUri);
+  }
+
+  public URI toUri() {
+    return URI.create(getValue());
+  }
+
+  public URI getResourceRoot() {
+    return URI.create(getValue() + "/");
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
@@ -12,14 +12,11 @@ import com.nimbusds.jose.jwk.ECKey;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.net.URI;
-import java.util.Optional;
 import java.util.UUID;
 
 public class WalletProviderClient {
 
-  private final URI base = URI.create(
-      Optional.ofNullable(System.getenv("DIGG_WALLET_ECOSYSTEM_WALLET_PROVIDER_BASE_URI"))
-          .orElse("https://localhost/wallet-provider") + "/");
+  private final URI base = ServiceIdentifier.WALLET_PROVIDER.getResourceRoot();
 
   public Response tryGetHealth() {
     return given()


### PR DESCRIPTION
Here we expand the automated checks for the links served by the PID issuer.

Specifically we makes the following changes:

 1. Explicitly check that the credentials issuer metadata location is compliant with the specification
 2. Explicitly check that all three metadata URLs with rewrite rules actually work by verifying the data returned from the endpoint
 3. Make these checks work regardless of whether they run on localhost or another environment

Previously these links were only checked implicitly by extracting the URLs from the PID issuer web interface.

See: https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-12.2.2

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
