### PR TITLE
refactor: improve readability of metadata retrieval test logic

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakClient.java
@@ -26,6 +26,14 @@ public class KeycloakClient {
     this.base = base;
   }
 
+  public Response tryGetOauthAuthorizationServerMetadata(
+      String realm, MetadataLocationStrategy strategy) {
+
+    return given().when().get(strategy.applyTo(
+        base.resolve("realms/" + realm),
+        "/.well-known/oauth-authorization-server"));
+  }
+
   public String getDpopAccessToken(
       String realm, ECKey key, Map<String, String> parameters) throws JOSEException {
 

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -74,8 +74,9 @@ public class KeycloakTest {
   public static Stream<Arguments> pidIssuerRealmMetadataUrls() {
     return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
         s.toString(),
-        s.applyTo(ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve(
-            "realms/pid-issuer-realm"), "oauth-authorization-server")));
+        s.applyTo(
+            ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve("realms/pid-issuer-realm"),
+            "/.well-known/oauth-authorization-server")));
   }
 
   @ParameterizedTest

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -6,20 +6,16 @@ package se.digg.wallet.ecosystem;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import java.net.URI;
 import java.util.Map;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class KeycloakTest {
@@ -71,19 +67,10 @@ public class KeycloakTest {
         "password", "password")));
   }
 
-  public static Stream<Arguments> pidIssuerRealmMetadataUrls() {
-    return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
-        s.toString(),
-        s.applyTo(
-            ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve("realms/pid-issuer-realm"),
-            "/.well-known/oauth-authorization-server")));
-  }
-
   @ParameterizedTest
-  @MethodSource("pidIssuerRealmMetadataUrls")
-  void servesMetadataForPidIssuerRealm(
-      String labelNotUsedInTestButIncludedInDisplayName, URI uri) {
-    given().when().get(uri)
+  @EnumSource(MetadataLocationStrategy.class)
+  void servesMetadataForPidIssuerRealm(MetadataLocationStrategy strategy) {
+    keycloak.tryGetOauthAuthorizationServerMetadata("pid-issuer-realm", strategy)
         .then()
         .assertThat().statusCode(200)
         .and().body("issuer", equalTo(ServiceIdentifier.KEYCLOAK.getResourceRoot().resolve(

--- a/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategy.java
+++ b/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategy.java
@@ -38,7 +38,7 @@ public enum MetadataLocationStrategy {
     try {
       return new URI(
           identifier.getScheme(), identifier.getAuthority(),
-          getPath(identifier.getPath(), "/.well-known/" + metadata),
+          getPath(identifier.getPath(), metadata),
           null, null);
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);

--- a/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategy.java
+++ b/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategy.java
@@ -15,8 +15,8 @@ public enum MetadataLocationStrategy {
    */
   BASIC {
     @Override
-    protected String getPath(String identifierPath, String metadataPath) {
-      return identifierPath + metadataPath;
+    protected String getPath(String identifierFragment, String metadataFragment) {
+      return identifierFragment + metadataFragment;
     }
   },
 
@@ -29,21 +29,21 @@ public enum MetadataLocationStrategy {
    */
   OID4VCI_COMPLIANT {
     @Override
-    protected String getPath(String identifierPath, String metadataPath) {
-      return metadataPath + identifierPath;
+    protected String getPath(String identifierFragment, String metadataFragment) {
+      return metadataFragment + identifierFragment;
     }
   };
 
-  public final URI applyTo(URI identifier, String metadata) {
+  public final URI applyTo(URI identifier, String metadataPathFragment) {
     try {
       return new URI(
           identifier.getScheme(), identifier.getAuthority(),
-          getPath(identifier.getPath(), metadata),
+          getPath(identifier.getPath(), metadataPathFragment),
           null, null);
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
     }
   }
 
-  protected abstract String getPath(String identifierPath, String metadataPath);
+  protected abstract String getPath(String identifierFragment, String metadataFragment);
 }

--- a/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategyTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategyTest.java
@@ -32,6 +32,6 @@ class MetadataLocationStrategyTest {
   @ParameterizedTest
   @MethodSource("uriExamples")
   void producesExpectedUris(MetadataLocationStrategy strategy, URI identifier, URI expected) {
-    assertThat(strategy.applyTo(identifier, "openid-credential-issuer"), is(expected));
+    assertThat(strategy.applyTo(identifier, "/.well-known/openid-credential-issuer"), is(expected));
   }
 }

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerClient.java
@@ -21,6 +21,7 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.EncryptedJWT;
+import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
 import java.net.URI;
 import java.security.interfaces.ECPrivateKey;
@@ -38,6 +39,18 @@ public class PidIssuerClient {
 
   public PidIssuerClient() {
     base = ServiceIdentifier.PID_ISSUER.getResourceRoot();
+  }
+
+  public Response tryGetOpenIdCredentialIssuerMetadata(MetadataLocationStrategy strategy) {
+    return given().when().get(strategy.applyTo(
+        ServiceIdentifier.PID_ISSUER.toUri(),
+        "/.well-known/openid-credential-issuer"));
+  }
+
+  public Response tryGetJwtVcIssuerMetadata(MetadataLocationStrategy strategy) {
+    return given().get(strategy.applyTo(
+        ServiceIdentifier.PID_ISSUER.toUri(),
+        "/.well-known/jwt-vc-issuer"));
   }
 
   public Map<String, String> getUsefulLinks() {

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -16,12 +16,12 @@ import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
-import java.net.URI;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class PidIssuerTest {
@@ -59,20 +59,10 @@ public class PidIssuerTest {
     given().when().get(link).then().assertThat().statusCode(200);
   }
 
-  public static Stream<Arguments> credentialIssuerMetadataUrls() {
-    return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
-        s.toString(),
-        s.applyTo(IDENTIFIER.toUri(), "/.well-known/openid-credential-issuer")));
-  }
-
   @ParameterizedTest
-  @MethodSource("credentialIssuerMetadataUrls")
-  void servesCredentialIssuerMetadata(
-      String labelNotUsedInTestButIncludedInDisplayName, URI uri) {
-
-    given()
-        .when()
-        .get(uri)
+  @EnumSource(MetadataLocationStrategy.class)
+  void servesCredentialIssuerMetadata(MetadataLocationStrategy strategy) {
+    pidIssuer.tryGetOpenIdCredentialIssuerMetadata(strategy)
         .then()
         .assertThat().statusCode(200)
         .and().body(
@@ -87,20 +77,10 @@ public class PidIssuerTest {
                 "realms/pid-issuer-realm").toString()));
   }
 
-  public static Stream<Arguments> jwtVcIssuerMetadataUrls() {
-    return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
-        s.toString(),
-        s.applyTo(IDENTIFIER.toUri(), "/.well-known/jwt-vc-issuer")));
-  }
-
   @ParameterizedTest
-  @MethodSource("jwtVcIssuerMetadataUrls")
-  void servesJwtVcIssuerMetadata(
-      String labelNotUsedInTestButIncludedInDisplayName, URI uri) {
-
-    given()
-        .when()
-        .get(uri)
+  @EnumSource(MetadataLocationStrategy.class)
+  void servesJwtVcIssuerMetadata(MetadataLocationStrategy strategy) {
+    pidIssuer.tryGetJwtVcIssuerMetadata(strategy)
         .then()
         .assertThat().statusCode(200)
         .and().body("issuer", is(IDENTIFIER.toString()))

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -62,7 +62,7 @@ public class PidIssuerTest {
   public static Stream<Arguments> credentialIssuerMetadataUrls() {
     return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
         s.toString(),
-        s.applyTo(IDENTIFIER.toUri(), "openid-credential-issuer")));
+        s.applyTo(IDENTIFIER.toUri(), "/.well-known/openid-credential-issuer")));
   }
 
   @ParameterizedTest
@@ -90,7 +90,7 @@ public class PidIssuerTest {
   public static Stream<Arguments> jwtVcIssuerMetadataUrls() {
     return Stream.of(MetadataLocationStrategy.values()).map(s -> Arguments.of(
         s.toString(),
-        s.applyTo(IDENTIFIER.toUri(), "jwt-vc-issuer")));
+        s.applyTo(IDENTIFIER.toUri(), "/.well-known/jwt-vc-issuer")));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
This change set contains some cleanup of the metadata retrieval test logic.

 1. We move some of the logic from the test classes into the service clients.
 2. We improve the naming inside the MetadataLocationStrategy enum.
 3. We move the responsibility of prepending ".well-known" to the metadata path from the MetadataLocationStrategy enum to its clients.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
