### PR TITLE
style: allow having closing parenthesis on a separate line

### DIFF
--- a/development/format/eclipse-java-google-style.xml
+++ b/development/format/eclipse-java-google-style.xml
@@ -340,5 +340,38 @@
     <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
     <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
     <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+
+    <!-- Custom rules below -->
+
+    <!--
+      Here we allow for having the closing parenthesis of an expression on a separate line
+      instead of the default rule always keeping it on the same line as the enclosed content.
+
+      <code>
+        // This style is now allowed
+        assertThat(actual, containsInAnyOrder(
+          "foo",
+          "bar",
+          "baz"
+        ));
+
+        // This style is still allowed, but no longer enforced
+        assertThat(actual, containsInAnyOrder(
+          "foo",
+          "bar",
+          "baz"));
+      </code>
+    -->
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_annotation" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_catch_clause" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_enum_constant_declaration" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_for_statement" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_if_while_statement" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_lambda_declaration" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_declaration" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_method_invocation" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_record_declaration" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_switch_statement" value="preserve_positions"/>
+    <setting id="org.eclipse.jdt.core.formatter.parentheses_positions_in_try_clause" value="preserve_positions"/>
   </profile>
 </profiles>

--- a/development/format/eclipse-java-google-style.xml
+++ b/development/format/eclipse-java-google-style.xml
@@ -3,7 +3,7 @@
   <profile kind="CodeFormatterProfile" name="GoogleStyle" version="13">
     <!-- Google style guide, https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml.
     Eclipse format, which works for mvn, vscode, intellij.
-    
+
     Slightly modified due to order formatting bug in mvnplugin
         See comments where changed, Otherwise identical.
         If changes, comment them, and why.


### PR DESCRIPTION
Here we modifiy the formatting rules to *allow* having the closing parenthesis of an expression on a separate line instead of the default rule which enforces the closing parenthesis to the same line as the enclosed content.

Example:

	// This style is now allowed
	assertThat(actual, containsInAnyOrder(
	  "foo",
	  "bar",
	  "baz"
	));

	// This style is still allowed, but no longer enforced
	assertThat(actual, containsInAnyOrder(
	  "foo",
	  "bar",
	  "baz"));

Having the closing parenthesis on a separate line can improve readability in some cases.

Note: If we want to enforce the new style we can use 'separate_lines_if_wrapped' instead. However, that could lead to
unneccessarily many new lines since consecutive parentheses will each go on a separate line.

See: https://help.eclipse.org/latest/topic/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.html
See: https://help.eclipse.org/latest/topic/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.html#PRESERVE_POSITIONS
See: https://help.eclipse.org/latest/topic/org.eclipse.jdt.doc.isv/reference/api/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.html#SEPARATE_LINES_IF_WRAPPED
Signed-off-by: Eric Thelin <extern.eric.thelin@digg.se>

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
