### PR TITLE
fix: remove excessive logging

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -158,7 +158,6 @@ public class WalletClientGatewayTest {
     var keycloakLoginPage = given()
         .filter(cookies)
         .redirects().follow(true)
-        .log().all()
         .urlEncodingEnabled(false)
         .get(redirectToKeycloakLogin.getHeader("Location"));
 
@@ -169,16 +168,12 @@ public class WalletClientGatewayTest {
         .redirects().follow(false)
         .formParam("username", "test1")
         .formParam("password", "test1")
-        .log()
-        .all()
         .post(loginAction);
 
     var applicationResponse = given()
         .filter(cookies)
         .redirects().follow(false)
         .urlEncodingEnabled(false)
-        .log()
-        .all()
         .get(loginResponse.getHeader("Location"));
 
     return applicationResponse.cookie("SESSION");


### PR DESCRIPTION
By logging the request data regardless of test status we pollute the test output of every test run. In RestAssuredSugar we configure RestAssured to log the request and response data if, and only if, the validation fails. This should be enough for most cases.

See: [RestAssuredSugar#given](https://github.com/diggsweden/wallet-ecosystem/blob/6070d18b15b22899084d784e49c88a24f5fd4685/src/test/java/se/digg/wallet/ecosystem/RestAssuredSugar.java#L18)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
