### PR TITLE
fix: accept leaked secrets in local configuration

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+title = "Wallet Ecosystem Gitleaks configuration"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+targetRules = ["generic-api-key", "private-key"]
+description = "We accept 'secrets' in our local docker configuration and our tests"
+paths = [
+    '^config/',
+    '^docker-compose.yaml$',
+    '^src/test/java/',
+
+    # This path was used in the first commits, but is no longer used.
+    # We still need to allow this path to avoid linting errors.
+    '^eudi-srv-pid-issuer/docker-compose/',
+]


### PR DESCRIPTION
We accept leaked secrets in the local Docker configuration and in our test code, since it is only for local use.

This fixes `just lint-secrets` on the main branch.

# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
