### PR TITLE
Chore/bump maven pmd plugin to 3.28.0

### DIFF
--- a/development/sast/pmd_default_java.xml
+++ b/development/sast/pmd_default_java.xml
@@ -57,7 +57,7 @@
     <rule ref="category/java/errorprone.xml/UnconditionalIfStatement" />
     <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary" />
     <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals" />
-    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable" />
+    <rule ref="category/java/errorprone.xml/UselessPureMethodCall" />
 
     <rule ref="category/java/multithreading.xml/AvoidThreadGroup" />
     <rule ref="category/java/multithreading.xml/DontCallThreadRun" />

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ SPDX-License-Identifier: CC0-1.0
     <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
     <checkstyle-maven-plugin.version>3.6.0</checkstyle-maven-plugin.version>
     <checkstyle.version>12.2.0</checkstyle.version>
-    <pmd-maven-plugin.version>3.27.0</pmd-maven-plugin.version>
+    <pmd-maven-plugin.version>3.28.0</pmd-maven-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Here we bump the PMD plugin to version 3.28.0 and adjust the rule set to avoid warnings after the upgrade. Please see the individual commits for details.

See: https://github.com/apache/maven-pmd-plugin

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
