### PR TITLE
test: add linter for version control

### DIFF
--- a/justfile
+++ b/justfile
@@ -179,6 +179,7 @@ lint-version-control:
         2. A linter automatically fixed a problem or reformatted the code.
 
       Please accept or discard any outstanding changes and try again."
+      return 1
     fi
 
 # ==================================================================================== #

--- a/justfile
+++ b/justfile
@@ -162,6 +162,7 @@ lint-java-fmt:
 [group('lint')]
 lint-container:
 
+# Detect unversioned changes
 [group('lint')]
 lint-version-control:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -162,6 +162,24 @@ lint-java-fmt:
 [group('lint')]
 lint-container:
 
+[group('lint')]
+lint-version-control:
+    #!/usr/bin/env bash
+    source "{{colors}}"
+    print_header "VERSION CONTROL"
+    if test -z "$(git status --porcelain | awk '{$1=$1};1')"; then
+      just_success "All changes are under version control"
+    else
+      just_error "Some changes are not under version control!
+
+      This can happen if
+
+        1. You forgot to version control your changes
+        2. A linter automatically fixed a problem or reformatted the code.
+
+      Please accept or discard any outstanding changes and try again."
+    fi
+
 # ==================================================================================== #
 # LINT-FIX - Auto-fix code issues
 # ==================================================================================== #


### PR DESCRIPTION
When running our automated checks we want to ensure that everything is version controlled. Otherwise there is a risk that we get false results, i.e. false positives or false negatives.

This is essentially a port of the corresponding check we had in the code_quality.sh script.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
