### PR TITLE
feat: allow skipping verifier backend health tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -217,6 +217,12 @@ In order to avoid test failures in those situations, you can skip those tests li
 env DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_KEYCLOAK_HEALTH=true just test
 ```
 
+Similarly, you can skip the verifier backend tests like so:
+
+```shell
+env DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_VERIFIER_BACKEND_HEALTH=true just test
+```
+
 ### Quality Checks
 
 This project uses `just` + `mise` for local quality checks.

--- a/src/test/java/se/digg/wallet/ecosystem/VerifierBackendTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/VerifierBackendTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 class VerifierBackendTest {
   private static final String dcqlId = UUID.randomUUID().toString();
@@ -33,6 +34,9 @@ class VerifierBackendTest {
   }
 
   @Test
+  @DisabledIfEnvironmentVariable(
+      named = "DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_VERIFIER_BACKEND_HEALTH",
+      matches = "true")
   void isHealthy() {
     verifierBackendClient
         .tryGetHealth()


### PR DESCRIPTION
In some configurations the verifier health health endpoint is not exposed for testing. In order to avoid test failures we allow for skipping those tests by using the environment variable `DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_VERIFIER_BACKEND_HEALTH`:

    env DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_VERIFIER_BACKEND_HEALTH=true mvn test

This is similar to the ability we already have for the Keycloak health tests.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
