### PR TITLE
fix: use wallet-provider v0.0.3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
       - wallet-ecosystem-network
 
   wallet-provider:
-    image: ghcr.io/diggsweden/wallet-provider:main
+    image: ghcr.io/diggsweden/wallet-provider:v0.0.3
     container_name: wallet-provider
     hostname: wallet-provider
     volumes:


### PR DESCRIPTION
The `main` tag points to a version released 4 months ago and is not compatible with the rest of the services in the ecosystem. By using `v0.0.3` we restore the result of `mvn test` to a succesful state.

See: https://github.com/diggsweden/wallet-provider/pkgs/container/wallet-provider/662177886?tag=v0.0.3
See: https://github.com/diggsweden/wallet-provider/pkgs/container/wallet-provider/527117692?tag=main

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
