### PR TITLE
test(client-gateway): get auth session ID from response body

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -60,8 +60,9 @@ public class WalletClientGatewayClient {
         .statusCode(200)
         .extract()
         .response()
-        .getHeaders()
-        .getValue("session");
+        .body()
+        .jsonPath()
+        .getString("sessionId");
   }
 
 


### PR DESCRIPTION
Session ID in the header is deprecated and the value from body should be used instead.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
