### PR TITLE
feat: add ability to generate architecture diagrams from compose file

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -135,6 +135,14 @@ or
 just
 ```
 
+### Documentation
+
+Generate documentation to `target/documentation`.
+
+```shell
+just document
+```
+
 ### Docker Compose Services
 
 Start all ecosystem services:

--- a/justfile
+++ b/justfile
@@ -76,6 +76,35 @@ npm-install:
     npm ci
 
 # ==================================================================================== #
+# DOCUMENTATION
+# ==================================================================================== #
+
+# Generate architecure diagrams from the Docker compose file
+[group('document')]
+document:
+    mkdir -p target/documentation
+    docker run \
+        --rm \
+        -v "$PWD":/data derlin/docker-compose-viz-mermaid \
+        /data/docker-compose.yaml \
+        --no-ports \
+        --no-volumes \
+        --no-networks \
+        --no-ilinks \
+        -f svg \
+        --out=/data/target/documentation/wallet-ecosystem-minimal.svg
+    docker run \
+        --rm \
+        -v "$PWD":/data derlin/docker-compose-viz-mermaid \
+        /data/docker-compose.yaml \
+        --ports \
+        --volumes \
+        --networks \
+        --ilinks \
+        -f svg \
+        --out=/data/target/documentation/wallet-ecosystem-detailed.svg
+
+# ==================================================================================== #
 # VERIFY - Quality assurance
 # ==================================================================================== #
 


### PR DESCRIPTION
By running `just document` we can now generate architecture diagrams from the services and interdependencies defined in the docker-compose.yaml file.

The diagrams are generated using the Docker Compose Viz (Mermaid) tool and stored in `target/documentation`.

See: https://derlin.github.io/docker-compose-viz-mermaid/

# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
