### PR TITLE
fix: add dependency between refimpl verifier frontend and backend

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -96,6 +96,8 @@ services:
   refimpl-verifier:
     image: ghcr.io/eu-digital-identity-wallet/eudi-web-verifier:v0.9.1
     container_name: refimpl-verifier
+    depends_on:
+      - refimpl-verifier-backend
     healthcheck:
       test: curl -f http://refimpl-verifier:4300/home || exit 1
       start_period: 15s


### PR DESCRIPTION
This ensures that the backend is up before we attempt to use it from the frontend. A side effect is also that the generated documentation of the service interdependencies will include the dependency.

# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
