### PR TITLE
test: versionless wua endpoint

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -23,16 +23,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class EndToEndTest {
 
   private final VerifierBackendClient verifierBackend = new VerifierBackendClient();
-  private final IssuanceHelper issuanceHelper = new IssuanceHelper();
   private final ObjectMapper objectMapper = new ObjectMapper();
 
-  @Test
-  void getCredential() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "wallet-unit-attestation",
+      "wallet-unit-attestation/v2"
+  })
+  void getCredential(String wuaPath) throws Exception {
+    IssuanceHelper issuanceHelper = new IssuanceHelper(new WalletProviderClient(wuaPath));
     // 1. Initialize transaction
     String nonce = UUID.randomUUID().toString();
     String dcqlId = UUID.randomUUID().toString();

--- a/src/test/java/se/digg/wallet/ecosystem/IssuanceHelper.java
+++ b/src/test/java/se/digg/wallet/ecosystem/IssuanceHelper.java
@@ -27,8 +27,16 @@ import java.util.Map;
 public class IssuanceHelper {
 
   private final KeycloakClient keycloak = new KeycloakClient();
-  private final WalletProviderClient walletProvider = new WalletProviderClient();
+  private final WalletProviderClient walletProvider;
   private final PidIssuerClient pidIssuer = new PidIssuerClient();
+
+  public IssuanceHelper() {
+    this(new WalletProviderClient());
+  }
+
+  public IssuanceHelper(WalletProviderClient walletProvider) {
+    this.walletProvider = walletProvider;
+  }
 
   public String createVpToken(String sdJwtVc, ECKey bindingKey, String nonce, String audience)
       throws Exception {

--- a/src/test/java/se/digg/wallet/ecosystem/IssuanceHelper.java
+++ b/src/test/java/se/digg/wallet/ecosystem/IssuanceHelper.java
@@ -85,7 +85,7 @@ public class IssuanceHelper {
                 "role", "user"));
 
     String nonce = pidIssuer.getNonce(accessToken, userJwk);
-    String walletAttestation = walletProvider.getWalletUnitAttestationV2(bindingKey, nonce);
+    String walletAttestation = walletProvider.getWalletUnitAttestation(bindingKey, nonce);
     String proof = createProof(bindingKey, walletAttestation, nonce);
     ECKey pidIssuerCredentialRequestEncryptionKey = pidIssuer.getCredentialRequestEncryptionKey();
     Map<String, Object> payloadJson =

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
@@ -36,7 +36,7 @@ public class WalletProviderClient {
         .get(base.resolve("actuator/health"));
   }
 
-  public String getWalletUnitAttestationV2(ECKey jwk, String nonce) throws JsonProcessingException {
+  public String getWalletUnitAttestation(ECKey jwk, String nonce) throws JsonProcessingException {
     return given()
         .when()
         .contentType(ContentType.JSON)

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
@@ -18,32 +18,12 @@ public class WalletProviderClient {
 
   private final URI base = ServiceIdentifier.WALLET_PROVIDER.getResourceRoot();
 
-  private static final String WUA_URL = "wallet-unit-attestation";
   private static final String WUA_V2_URL = "wallet-unit-attestation/v2";
 
   public Response tryGetHealth() {
     return given()
         .when()
         .get(base.resolve("actuator/health"));
-  }
-
-  @Deprecated(forRemoval = true)
-  public String getWalletUnitAttestation(ECKey jwk) throws JsonProcessingException {
-    return given()
-        .when()
-        .contentType(ContentType.JSON)
-        .body(
-            String.format("""
-                { "walletId": "%s", "jwk": %s }""",
-                UUID.randomUUID(),
-                new ObjectMapper().writeValueAsString(jwk.toPublicJWK().toJSONString())))
-        .post(base.resolve(WUA_URL))
-        .then()
-        .assertThat()
-        .statusCode(200)
-        .extract()
-        .body()
-        .asString();
   }
 
   public String getWalletUnitAttestationV2(ECKey jwk, String nonce) throws JsonProcessingException {

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderClient.java
@@ -20,6 +20,16 @@ public class WalletProviderClient {
 
   private static final String WUA_V2_URL = "wallet-unit-attestation/v2";
 
+  private final String path;
+
+  public WalletProviderClient() {
+    this(WUA_V2_URL);
+  }
+
+  public WalletProviderClient(String path) {
+    this.path = path;
+  }
+
   public Response tryGetHealth() {
     return given()
         .when()
@@ -40,7 +50,7 @@ public class WalletProviderClient {
                 UUID.randomUUID(),
                 new ObjectMapper().writeValueAsString(jwk.toPublicJWK().toJSONString()),
                 nonce))
-        .post(base.resolve(WUA_V2_URL))
+        .post(base.resolve(path))
         .then()
         .assertThat()
         .statusCode(200)

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
@@ -35,7 +35,7 @@ public class WalletProviderTest {
   @Deprecated
   /* This is a temporary test until we have migrated all clients to the versionless endpoint */
   void createsWalletUnitAttestationOnSpecificPath(String path) throws Exception {
-    String wua = new WalletProviderClient(path).getWalletUnitAttestationV2(
+    String wua = new WalletProviderClient(path).getWalletUnitAttestation(
         new ECKeyGenerator(Curve.P_256).generate(),
         "nonce");
 
@@ -46,8 +46,8 @@ public class WalletProviderTest {
   @ParameterizedTest
   @ValueSource(strings = {"nonce", ""})
   @NullSource
-  void createsWalletUnitAttestationV2(String nonce) throws Exception {
-    String wua = walletProvider.getWalletUnitAttestationV2(
+  void createsWalletUnitAttestation(String nonce) throws Exception {
+    String wua = walletProvider.getWalletUnitAttestation(
         new ECKeyGenerator(Curve.P_256).generate(),
         nonce);
 

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
@@ -27,16 +27,6 @@ public class WalletProviderTest {
         .and().body("status", equalTo("UP"));
   }
 
-  @Deprecated(forRemoval = true)
-  @Test
-  void createsWalletUnitAttestation() throws Exception {
-    String wua = walletProvider.getWalletUnitAttestation(
-        new ECKeyGenerator(Curve.P_256).generate());
-
-    assertThat(wua, matchesPattern(
-        "^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
-  }
-
   @ParameterizedTest
   @ValueSource(strings = {"nonce", ""})
   @NullSource

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
@@ -28,6 +28,22 @@ public class WalletProviderTest {
   }
 
   @ParameterizedTest
+  @ValueSource(strings = {
+      "wallet-unit-attestation",
+      "wallet-unit-attestation/v2"
+  })
+  @Deprecated
+  /* This is a temporary test until we have migrated all clients to the versionless endpoint */
+  void createsWalletUnitAttestationOnSpecificPath(String path) throws Exception {
+    String wua = new WalletProviderClient(path).getWalletUnitAttestationV2(
+        new ECKeyGenerator(Curve.P_256).generate(),
+        "nonce");
+
+    assertThat(wua, matchesPattern(
+        "^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
+  }
+
+  @ParameterizedTest
   @ValueSource(strings = {"nonce", ""})
   @NullSource
   void createsWalletUnitAttestationV2(String nonce) throws Exception {


### PR DESCRIPTION
Here we add tests for the versionless create WUA endpoint in wallet-provider. We also update the end-to-end test to run on both endpoints to ensure that both flows are supported. Additionally we remove the deprecated tests for the legacy "wallet-unit-attestation" endpoint since that one is replaced with the v2 logic on the same path in wallet-provider.

Note: The end-to-end test using the versionless "wallet-unit-attestation" endpoint fails until we update to a version of wallet-provider that implements the correct behavior

See: diggsweden/wallet-provider#42 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
