### PR TITLE
test(client-gateway): remove wua/v3

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -9,6 +9,8 @@ import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
 import java.net.URI;
 
 public class WalletClientGatewayClient {
@@ -89,15 +91,16 @@ public class WalletClientGatewayClient {
         .get(base.resolve("attribute-attestations/%s".formatted(id)));
   }
 
-  public Response createWalletUnitAttestation(String sessionId, String nonce, String path)
-      throws Exception {
-    String wuaUrl = path
-        + (nonce != null ? "?nonce=" + nonce : "");
-
-    return given()
+  public Response createWalletUnitAttestation(String sessionId, String nonce) {
+    RequestSpecification request = given()
         .when()
         .contentType(ContentType.JSON)
-        .header("session", sessionId)
-        .post(base.resolve(wuaUrl));
+        .header("session", sessionId);
+
+    if (nonce != null) {
+      request.queryParam("nonce", nonce);
+    }
+
+    return request.post(base.resolve("wua"));
   }
 }

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 @TestMethodOrder(OrderAnnotation.class)
 public class WalletClientGatewayTest {
 
-  public static final List<String> WUA_PATH = List.of("wua", "wua/v3");
   public static final List<String> ACCOUNTS_PATH = List.of("accounts", "accounts/v1");
   private final WalletClientGatewayClient walletClientGateway = new WalletClientGatewayClient();
   private static final String KEY_ID = "123";
@@ -197,10 +196,9 @@ public class WalletClientGatewayTest {
         .and().body("hsmId", equalTo("cbe80ad0-6a7d-4a5a-9891-8b4e95fa4d49"));
   }
 
-  @ParameterizedTest
-  @FieldSource("WUA_PATH")
-  void createsWalletUnitAttestation(String path) throws Exception {
-    walletClientGateway.createWalletUnitAttestation(session, null, path)
+  @Test
+  void createsWalletUnitAttestation() throws Exception {
+    walletClientGateway.createWalletUnitAttestation(session, null, "wua")
         .then()
         .assertThat().statusCode(201).and()
         .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
@@ -216,12 +214,11 @@ public class WalletClientGatewayTest {
         .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
   }
 
-  @ParameterizedTest
-  @FieldSource("WUA_PATH")
-  void createsWalletUnitAttestation_withEmptyNonce_shouldGiveBadRequest(String path)
+  @Test
+  void createsWalletUnitAttestation_withEmptyNonce_shouldGiveBadRequest()
       throws Exception {
     String emptyNonce = "";
-    walletClientGateway.createWalletUnitAttestation(session, emptyNonce, path)
+    walletClientGateway.createWalletUnitAttestation(session, emptyNonce, "wua")
         .then()
         .assertThat().statusCode(400);
   }

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -198,7 +198,7 @@ public class WalletClientGatewayTest {
 
   @Test
   void createsWalletUnitAttestation() throws Exception {
-    walletClientGateway.createWalletUnitAttestation(session, null, "wua")
+    walletClientGateway.createWalletUnitAttestation(session, null)
         .then()
         .assertThat().statusCode(201).and()
         .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
@@ -208,7 +208,7 @@ public class WalletClientGatewayTest {
   @ValueSource(strings = {"nonce"})
   @NullSource
   void createsWalletUnitAttestationWithAndWithoutNonce(String nonce) throws Exception {
-    walletClientGateway.createWalletUnitAttestation(session, nonce, "wua")
+    walletClientGateway.createWalletUnitAttestation(session, nonce)
         .then()
         .assertThat().statusCode(201).and()
         .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
@@ -218,7 +218,7 @@ public class WalletClientGatewayTest {
   void createsWalletUnitAttestation_withEmptyNonce_shouldGiveBadRequest()
       throws Exception {
     String emptyNonce = "";
-    walletClientGateway.createWalletUnitAttestation(session, emptyNonce, "wua")
+    walletClientGateway.createWalletUnitAttestation(session, emptyNonce)
         .then()
         .assertThat().statusCode(400);
   }


### PR DESCRIPTION
The WUA endpoint in wallet client gateway is now versionless. Update the test to reflect that.

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
