### PR TITLE
feat(traefik): configure default TLS certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ echo $HOST_IP
 could yield `172.17.0.1`. In that case, you would edit your docker config and restart docker which would result in something like this:
 
 ```shell
-cat ~/.docker/config.json 
+cat ~/.docker/config.json
 ```
 
 ```json
@@ -132,5 +132,5 @@ Generate a certificate and key pair:
 ```sh
 source set-host.sh
 mkdir -p config/traefik/certs
-mkcert --cert-file ./config/traefik/certs/wallet-cert.pem --key-file ./config/traefik/certs/wallet-key.pem "*.wallet.local" localhost 127.0.0.1 ::1
+mkcert --cert-file ./config/traefik/certs/wallet-cert.pem --key-file ./config/traefik/certs/wallet-key.pem "*.wallet.local" localhost 127.0.0.1 ::1 10.0.2.2
 ```

--- a/config/traefik/tls.yml
+++ b/config/traefik/tls.yml
@@ -1,8 +1,12 @@
 # SPDX-FileCopyrightText: 2025 The Wallet Ecosystem Authors
 #
 # SPDX-License-Identifier: CC0-1.0
-
 tls:
+  stores:
+    default:
+      defaultCertificate:
+        certFile: /etc/traefik/certs/wallet-cert.pem
+        keyFile: /etc/traefik/certs/wallet-key.pem
   certificates:
     - certFile: /etc/traefik/certs/wallet-cert.pem
       keyFile: /etc/traefik/certs/wallet-key.pem


### PR DESCRIPTION
Explicitly sets default TLS certificates instead of falling back to the built-in Traefik certificate.

This allows Android emulators to connect to services under Traefik. The The Android emulator does not always send SNI (Server Name Indication) when connecting, causing Traefik to serve its default certificate. Setting an explicit default ensures the correct cert is being served.

Also adds the Android emulator IP to the mkcert command in README.md

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
