### PR TITLE
feat: allow API key override

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -216,6 +216,15 @@ env DIGG_WALLET_ECOSYSTEM_WALLET_PROVIDER_BASE_URI=https://wallet-provider.examp
     just test
 ```
 
+When your host is configured with a specific API key you can configure the test
+suite like so:
+
+```shell
+env DIGG_WALLET_ECOSYSTEM_WALLET_CLIENT_GATEWAY_BASE_URI=https://api.example.com \
+    DIGG_WALLET_ECOSYSTEM_WALLET_CLIENT_GATEWAY_API_KEY=my_api_key \
+    just test
+```
+
 #### Skipping Keycloak health tests
 
 Under some configurations the Keycloak health endpoints are not exposed.

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -27,6 +27,7 @@ import io.restassured.filter.cookie.CookieFilter;
 import io.restassured.http.ContentType;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -42,6 +43,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class WalletClientGatewayTest {
 
   public static final List<String> ACCOUNTS_PATH = List.of("accounts", "accounts/v1");
+  public static final String API_KEY = Optional.ofNullable(System.getenv(
+      "DIGG_WALLET_ECOSYSTEM_WALLET_CLIENT_GATEWAY_API_KEY")).orElse("apikey");
   private final WalletClientGatewayClient walletClientGateway = new WalletClientGatewayClient();
   private static final String KEY_ID = "123";
   private static ECKey ecKey;
@@ -102,8 +105,8 @@ public class WalletClientGatewayTest {
           "telephoneNumber": "070123123123",
           "publicKey": %s
         }""".formatted(ecKey.toPublicJWK().toJSONString());
-    var apiKey = "apikey";
-    var accountId = walletClientGateway.createAccountByApiKey(accountRequestBody, apiKey, path);
+    var accountId = walletClientGateway.createAccountByApiKey(
+        accountRequestBody, API_KEY, path);
 
     assertAll(
         () -> assertNotNull(accountId),
@@ -147,9 +150,8 @@ public class WalletClientGatewayTest {
           "telephoneNumber": "070123123123",
           "publicKey": %s
         }""".formatted(ecKey.toPublicJWK().toJSONString());
-    var apiKey = "apikey";
-    var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, apiKey, "accounts");
+    var accountId = walletClientGateway.createAccountByApiKey(
+        accountRequestBody, API_KEY, "accounts");
 
     // step two, create challenge
     // use nonce to created signedJwt


### PR DESCRIPTION
This is useful for when running the test suite on a host that uses a custom API key.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
