### PR TITLE
fix: remove reference to refimpl-verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ docker compose up
 | Service | URL | Description |
 |---|---|---|
 | Demo verifier | <https://localhost/demo-verifier> | Our verifier demo service |
-| EU reference verifier | <https://refimpl-verifier.wallet.local> | EU's reference implementation of a verifier |
 | EU reference verifier backend | <https://localhost/refimpl-verifier-backend> | Backend used by both verifier implementations |
 | EU reference PID issuer | <https://localhost/pid-issuer> | EU's reference implementation of a PID issuer |
 | Keycloak | <https://localhost/idp> | Identity provider for the PID issuer |


### PR DESCRIPTION
We recently removed the refimpl-verifier service, but forgot to remove it from the documentation.

See: commit f8602c11ec35adc37c78b8d28324f1e49967422d

# Pull Request Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
