### PR TITLE
feat: allow exclusion of specific test cases

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -226,6 +226,17 @@ Similarly, you can skip the verifier backend tests like so:
 env DIGG_WALLET_ECOSYSTEM_SKIP_TESTS_FOR_VERIFIER_BACKEND_HEALTH=true just test
 ```
 
+#### Excluding entire test cases
+
+To exclude one or more test cases you can run the tests with Maven like so:
+
+```shell
+mvn test -Dtest.excludes='TraefikTest,WalletAccountTest,WalletAttributeAttestationTest'
+```
+
+The command above will run all test cases except
+TraefikTest, WalletAccountTest and WalletAttributeAttestationTest.
+
 ### Quality Checks
 
 This project uses `just` + `mise` for local quality checks.

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@ SPDX-License-Identifier: CC0-1.0
     <checkstyle-maven-plugin.version>3.6.0</checkstyle-maven-plugin.version>
     <checkstyle.version>12.2.0</checkstyle.version>
     <pmd-maven-plugin.version>3.28.0</pmd-maven-plugin.version>
+    <test.excludes/>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -87,6 +88,11 @@ SPDX-License-Identifier: CC0-1.0
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.4</version>
+        <configuration>
+          <excludes>
+            <exclude>${test.excludes}</exclude>
+          </excludes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
Now you can exclude specific test cases like so:

	mvn test -Dtest.excludes='ExcludedTest,AnotherExcludedTest'

See: https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html#exclusions

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
