### PR TITLE
test: create account by api key default

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -31,8 +31,8 @@ public class WalletClientGatewayClient {
         .cookie("SESSION", oidcSession)
         .post(base.resolve("oidc/accounts/v1"))
         .then()
-        .assertThat()
-        .statusCode(201).and()
+        .assertThat().statusCode(201)
+        .and().body("accountId", not(blankOrNullString()))
         .extract().body().jsonPath().getString("accountId");
   }
 
@@ -43,8 +43,8 @@ public class WalletClientGatewayClient {
         .header("X-API-KEY", apiKey)
         .post(base.resolve(path))
         .then()
-        .assertThat()
-        .statusCode(201).and()
+        .assertThat().statusCode(201)
+        .and().body("accountId", not(blankOrNullString()))
         .extract().body().jsonPath().getString("accountId");
   }
 

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -5,7 +5,6 @@
 package se.digg.wallet.ecosystem;
 
 import static org.hamcrest.Matchers.blankOrNullString;
-import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
@@ -79,8 +78,8 @@ public class WalletClientGatewayClient {
         .header("Session", sessionId)
         .post(base.resolve("attribute-attestations"))
         .then()
-        .assertThat().statusCode(201).and()
-        .body("id", not(emptyString()))
+        .assertThat().statusCode(201)
+        .and().body("id", not(blankOrNullString()))
         .extract().body().jsonPath().getString("id");
   }
 

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -84,14 +84,14 @@ public class WalletClientGatewayClient {
         .extract().body().jsonPath().getString("id");
   }
 
-  public Response getAttributeAttestation(String sessionId, String id) {
+  public Response tryGetAttributeAttestation(String sessionId, String id) {
     return given()
         .when()
         .header("Session", sessionId)
         .get(base.resolve("attribute-attestations/%s".formatted(id)));
   }
 
-  public Response createWalletUnitAttestation(String sessionId, String nonce) {
+  public Response tryCreateWalletUnitAttestation(String sessionId, String nonce) {
     RequestSpecification request = given()
         .when()
         .contentType(ContentType.JSON)

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -24,6 +24,7 @@ public class WalletClientGatewayClient {
         .get(base.resolve("actuator/health"));
   }
 
+  @Deprecated
   public String createAccountByOidc(String postBody, String oidcSession) {
     return given()
         .when().contentType(ContentType.JSON).body(postBody)

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -4,12 +4,12 @@
 
 package se.digg.wallet.ecosystem;
 
+import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
 import io.restassured.http.ContentType;
-import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import java.net.URI;
@@ -61,7 +61,7 @@ public class WalletClientGatewayClient {
         .getString("nonce");
   }
 
-  public ExtractableResponse<Response> respondToChallenge(String signedJwt) {
+  public String respondToChallenge(String signedJwt) {
     return given()
         .when().contentType(ContentType.JSON).body("""
             {
@@ -69,7 +69,11 @@ public class WalletClientGatewayClient {
             }""".formatted(signedJwt))
         .post(base.resolve("public/auth/session/response"))
         .then()
-        .assertThat().statusCode(200).extract();
+        .assertThat().statusCode(200)
+        .and().body("sessionId", not(blankOrNullString()))
+        // Deprecated header
+        .and().and().header("session", not(blankOrNullString()))
+        .extract().body().jsonPath().get("sessionId");
   }
 
   public String createAttributeAttestation(String sessionId, String postBody) {

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -72,8 +72,7 @@ public class WalletClientGatewayClient {
         .assertThat().statusCode(200).extract();
   }
 
-  public String createAttributeAttestation(String sessionId, String postBody)
-      throws Exception {
+  public String createAttributeAttestation(String sessionId, String postBody) {
     return given().when().contentType(ContentType.JSON).body(postBody)
         .header("Session", sessionId)
         .post(base.resolve("attribute-attestations"))

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -54,7 +54,8 @@ public class WalletClientGatewayClient {
             base.resolve("public/auth/session/challenge?accountId=%s&keyId=%s"
                 .formatted(accountId, keyId)))
         .then()
-        .assertThat().statusCode(200).and()
+        .assertThat().statusCode(200)
+        .and().body("nonce", not(blankOrNullString()))
         .extract().body().jsonPath().getString("nonce");
   }
 

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -4,13 +4,14 @@
 
 package se.digg.wallet.ecosystem;
 
+import static org.hamcrest.Matchers.emptyString;
+import static org.hamcrest.Matchers.not;
 import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-
 import java.net.URI;
 
 public class WalletClientGatewayClient {
@@ -78,6 +79,7 @@ public class WalletClientGatewayClient {
         .post(base.resolve("attribute-attestations"))
         .then()
         .assertThat().statusCode(201).and()
+        .body("id", not(emptyString()))
         .extract()
         .body()
         .jsonPath()

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -56,10 +56,7 @@ public class WalletClientGatewayClient {
                 .formatted(accountId, keyId)))
         .then()
         .assertThat().statusCode(200).and()
-        .extract()
-        .body()
-        .jsonPath()
-        .getString("nonce");
+        .extract().body().jsonPath().getString("nonce");
   }
 
   public String respondToChallenge(String signedJwt) {
@@ -84,10 +81,7 @@ public class WalletClientGatewayClient {
         .then()
         .assertThat().statusCode(201).and()
         .body("id", not(emptyString()))
-        .extract()
-        .body()
-        .jsonPath()
-        .getString("id");
+        .extract().body().jsonPath().getString("id");
   }
 
   public Response getAttributeAttestation(String sessionId, String id) {

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -88,7 +88,7 @@ public class WalletClientGatewayTest {
         }""";
     var createdId = walletClientGateway.createAttributeAttestation(session, postBody);
 
-    walletClientGateway.getAttributeAttestation(session, createdId)
+    walletClientGateway.tryGetAttributeAttestation(session, createdId)
         .then()
         .assertThat().statusCode(200)
         .and().body("hsmId", equalTo("cbe80ad0-6a7d-4a5a-9891-8b4e95fa4d49"));
@@ -96,7 +96,7 @@ public class WalletClientGatewayTest {
 
   @Test
   void createsWalletUnitAttestation() {
-    walletClientGateway.createWalletUnitAttestation(session, null)
+    walletClientGateway.tryCreateWalletUnitAttestation(session, null)
         .then()
         .assertThat().statusCode(201).and()
         .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
@@ -106,7 +106,7 @@ public class WalletClientGatewayTest {
   @ValueSource(strings = {"nonce"})
   @NullSource
   void createsWalletUnitAttestationWithAndWithoutNonce(String nonce) {
-    walletClientGateway.createWalletUnitAttestation(session, nonce)
+    walletClientGateway.tryCreateWalletUnitAttestation(session, nonce)
         .then()
         .assertThat().statusCode(201).and()
         .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
@@ -115,7 +115,7 @@ public class WalletClientGatewayTest {
   @Test
   void createsWalletUnitAttestation_withEmptyNonce_shouldGiveBadRequest() {
     String emptyNonce = "";
-    walletClientGateway.createWalletUnitAttestation(session, emptyNonce)
+    walletClientGateway.tryCreateWalletUnitAttestation(session, emptyNonce)
         .then()
         .assertThat().statusCode(400);
   }

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -48,13 +48,7 @@ public class WalletClientGatewayTest {
   @BeforeAll
   static void beforeAll() throws Exception {
     var ecKey = generateKey();
-
     var accountId = createAccountByApiKey(ecKey);
-
-    assertAll(
-        () -> assertNotNull(accountId),
-        () -> assertFalse(accountId.isEmpty()));
-
     var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
     var signedJwt = createSignedJwt(ecKey, nonce);
     session = walletClientGateway.respondToChallenge(signedJwt);
@@ -70,12 +64,8 @@ public class WalletClientGatewayTest {
 
   @Test
   @Deprecated
-  void createAccount_usingOidc_shouldReturnAccountId() throws Exception {
-    var accountId = createAccountByOidc(generateKey());
-
-    assertAll(
-        () -> assertNotNull(accountId),
-        () -> assertFalse(accountId.isEmpty()));
+  void createAccount_usingOidc_shouldSucceed() {
+    assertDoesNotThrow(() -> createAccountByOidc(generateKey()));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -27,7 +27,6 @@ import io.restassured.filter.cookie.CookieFilter;
 import io.restassured.http.ContentType;
 import java.util.Date;
 import java.util.Optional;
-import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
@@ -133,8 +132,6 @@ public class WalletClientGatewayTest {
         "attestationData": "string"
         }""";
     var createdId = walletClientGateway.createAttributeAttestation(session, postBody);
-
-    UUID.fromString(createdId); // verify it's a valid uuid
 
     walletClientGateway.getAttributeAttestation(session, createdId)
         .then()

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -52,14 +52,6 @@ public class WalletClientGatewayTest {
     ecKey = generateKey();
   }
 
-  @Test
-  void appActuatorHealth_status_shouldReturnUP() {
-    walletClientGateway.tryGetHealth()
-        .then()
-        .assertThat().statusCode(200)
-        .and().body("status", equalTo("UP"));
-  }
-
   @BeforeEach
   void createSession() throws Exception {
     var accountId = createAccountByApiKey(ecKey);
@@ -82,6 +74,14 @@ public class WalletClientGatewayTest {
     assertAll(
         () -> assertNotNull(sessionFromDeprecatedHeader),
         () -> assertFalse(sessionFromDeprecatedHeader.isEmpty()));
+  }
+
+  @Test
+  void appActuatorHealth_status_shouldReturnUP() {
+    walletClientGateway.tryGetHealth()
+        .then()
+        .assertThat().statusCode(200)
+        .and().body("status", equalTo("UP"));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 @TestMethodOrder(OrderAnnotation.class)
 public class WalletClientGatewayTest {
 
-  public static final String API_KEY = Optional.ofNullable(System.getenv(
+  private static final String API_KEY = Optional.ofNullable(System.getenv(
       "DIGG_WALLET_ECOSYSTEM_WALLET_CLIENT_GATEWAY_API_KEY")).orElse("apikey");
   private static final WalletClientGatewayClient walletClientGateway =
       new WalletClientGatewayClient();

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -62,7 +62,7 @@ public class WalletClientGatewayTest {
 
   @BeforeEach
   void createSession() throws Exception {
-    var accountId = createAccountByOidc(ecKey);
+    var accountId = createAccountByApiKey(ecKey);
 
     assertAll(
         () -> assertNotNull(accountId),
@@ -85,8 +85,9 @@ public class WalletClientGatewayTest {
   }
 
   @Test
-  void createAccount_usingApiKeyAuth_shouldReturnAccountId() throws Exception {
-    var accountId = createAccountByApiKey(generateKey());
+  @Deprecated
+  void createAccount_usingOidc_shouldReturnAccountId() throws Exception {
+    var accountId = createAccountByOidc(generateKey());
 
     assertAll(
         () -> assertNotNull(accountId),
@@ -94,10 +95,11 @@ public class WalletClientGatewayTest {
   }
 
   @Test
-  void createAccountAndLoginWithChallenge_usingApiKey_shouldReturnSessionId() throws Exception {
+  @Deprecated
+  void createAccountAndLoginWithChallenge_usingOidc_shouldReturnSessionId() throws Exception {
     var ecKey = generateKey();
     // step one, create Account
-    var accountId = createAccountByApiKey(ecKey);
+    var accountId = createAccountByOidc(ecKey);
 
     // step two, create challenge
     // use nonce to created signedJwt

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -29,8 +29,8 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,8 +45,6 @@ public class WalletClientGatewayTest {
   private final WalletClientGatewayClient walletClientGateway = new WalletClientGatewayClient();
   private static final String KEY_ID = "123";
   private static ECKey ecKey;
-  private static String oidcSession;
-  private static String accountId;
   private static String session;
 
   @BeforeAll
@@ -62,20 +60,15 @@ public class WalletClientGatewayTest {
         .and().body("status", equalTo("UP"));
   }
 
-  @Test
-  @Order(1)
-  void login_usingOidcAuth_shouldReturnSession() throws Exception {
-    oidcSession = oidcLogin();
+  @BeforeEach
+  void createSession() throws Exception {
+    var oidcSession = oidcLogin();
 
     assertAll(
         () -> assertNotNull(oidcSession),
         () -> assertFalse(oidcSession.isEmpty()));
-  }
 
-  @Test
-  @Order(2)
-  void createAccount_usingOidcAuth_shouldReturnAccountId() throws Exception {
-    accountId = walletClientGateway.createAccountByOidc(
+    var accountId = walletClientGateway.createAccountByOidc(
         """
                 {
                   "emailAdress": "test@hej.se",
@@ -88,10 +81,24 @@ public class WalletClientGatewayTest {
     assertAll(
         () -> assertNotNull(accountId),
         () -> assertFalse(accountId.isEmpty()));
+
+    var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
+    var signedJwt = createSignedJwt(ecKey, nonce);
+    var response = walletClientGateway.respondToChallenge(signedJwt);
+    session = response.jsonPath().get("sessionId");
+
+    assertAll(
+        () -> assertNotNull(session),
+        () -> assertFalse(session.isEmpty()));
+
+    var sessionFromDeprecatedHeader = response.response().getHeaders().getValue("session");
+
+    assertAll(
+        () -> assertNotNull(sessionFromDeprecatedHeader),
+        () -> assertFalse(sessionFromDeprecatedHeader.isEmpty()));
   }
 
   @Test
-  @Order(3)
   void createAccount_usingApiKeyAuth_shouldReturnAccountId() throws Exception {
     var ecKey = generateKey();
     var accountRequestBody = """
@@ -107,32 +114,6 @@ public class WalletClientGatewayTest {
     assertAll(
         () -> assertNotNull(accountId),
         () -> assertFalse(accountId.isEmpty()));
-  }
-
-  @Test
-  @Order(4)
-  void loginChallenge_signedJwt_shouldReturnSessionInBody() throws Exception {
-    var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
-    var signedJwt = createSignedJwt(ecKey, nonce);
-    var response = walletClientGateway.respondToChallenge(signedJwt);
-    session = response.jsonPath().get("sessionId");
-
-    assertAll(
-        () -> assertNotNull(session),
-        () -> assertFalse(session.isEmpty()));
-  }
-
-  @Test
-  @Order(5)
-  void loginChallenge_signedJwt_shouldReturnSessionInHeader_deprecated() throws Exception {
-    var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
-    var signedJwt = createSignedJwt(ecKey, nonce);
-    var response = walletClientGateway.respondToChallenge(signedJwt);
-    session = response.response().getHeaders().getValue("session");
-
-    assertAll(
-        () -> assertNotNull(session),
-        () -> assertFalse(session.isEmpty()));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -211,7 +211,7 @@ public class WalletClientGatewayTest {
 
     var redirectToKeycloak = given()
         .filter(cookies)
-        .when().contentType(ContentType.JSON).body("bogusbody")
+        .when().contentType(ContentType.JSON)
         .post(ServiceIdentifier.WALLET_CLIENT_GATEWAY.getResourceRoot().resolve("oidc/accounts/v1"))
         .then()
         .assertThat()

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -123,8 +123,7 @@ public class WalletClientGatewayTest {
   }
 
   @Test
-  void createsAndGetAttributeAttestation()
-      throws Exception {
+  void createsAndGetAttributeAttestation() {
     var postBody = """
         {
         "hsmId": "cbe80ad0-6a7d-4a5a-9891-8b4e95fa4d49",
@@ -140,7 +139,7 @@ public class WalletClientGatewayTest {
   }
 
   @Test
-  void createsWalletUnitAttestation() throws Exception {
+  void createsWalletUnitAttestation() {
     walletClientGateway.createWalletUnitAttestation(session, null)
         .then()
         .assertThat().statusCode(201).and()
@@ -150,7 +149,7 @@ public class WalletClientGatewayTest {
   @ParameterizedTest
   @ValueSource(strings = {"nonce"})
   @NullSource
-  void createsWalletUnitAttestationWithAndWithoutNonce(String nonce) throws Exception {
+  void createsWalletUnitAttestationWithAndWithoutNonce(String nonce) {
     walletClientGateway.createWalletUnitAttestation(session, nonce)
         .then()
         .assertThat().statusCode(201).and()
@@ -158,8 +157,7 @@ public class WalletClientGatewayTest {
   }
 
   @Test
-  void createsWalletUnitAttestation_withEmptyNonce_shouldGiveBadRequest()
-      throws Exception {
+  void createsWalletUnitAttestation_withEmptyNonce_shouldGiveBadRequest() {
     String emptyNonce = "";
     walletClientGateway.createWalletUnitAttestation(session, emptyNonce)
         .then()

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -7,7 +7,7 @@ package se.digg.wallet.ecosystem;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
@@ -57,18 +57,7 @@ public class WalletClientGatewayTest {
 
     var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
     var signedJwt = createSignedJwt(ecKey, nonce);
-    var response = walletClientGateway.respondToChallenge(signedJwt);
-    session = response.jsonPath().get("sessionId");
-
-    assertAll(
-        () -> assertNotNull(session),
-        () -> assertFalse(session.isEmpty()));
-
-    var sessionFromDeprecatedHeader = response.response().getHeaders().getValue("session");
-
-    assertAll(
-        () -> assertNotNull(sessionFromDeprecatedHeader),
-        () -> assertFalse(sessionFromDeprecatedHeader.isEmpty()));
+    session = walletClientGateway.respondToChallenge(signedJwt);
   }
 
   @Test
@@ -91,7 +80,7 @@ public class WalletClientGatewayTest {
 
   @Test
   @Deprecated
-  void createAccountAndLoginWithChallenge_usingOidc_shouldReturnSessionId() throws Exception {
+  void createAccountAndLoginWithChallenge_usingOidc_shouldSucceed() throws Exception {
     var ecKey = generateKey();
     // step one, create Account
     var accountId = createAccountByOidc(ecKey);
@@ -101,25 +90,8 @@ public class WalletClientGatewayTest {
     var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
     var signedJwt = createSignedJwt(ecKey, nonce);
 
-    // step three, post response and expect a session in the header
-    var sessionResponse = walletClientGateway.respondToChallenge(signedJwt).response();
-
-    // Assert session response
-    var actualBodySessionId = sessionResponse
-        .body()
-        .jsonPath()
-        .getString("sessionId");
-
-    var actualHeaderSessionId = sessionResponse
-        .getHeaders()
-        .getValue("Session");
-
-    assertAll(
-        () -> assertNotNull(actualBodySessionId),
-        () -> assertFalse(actualBodySessionId.isEmpty()),
-        () -> assertNotNull(actualHeaderSessionId),
-        () -> assertFalse(actualHeaderSessionId.isEmpty()),
-        () -> assertEquals(actualBodySessionId, actualHeaderSessionId));
+    // step three, post response and expect success
+    assertDoesNotThrow(() -> walletClientGateway.respondToChallenge(signedJwt));
   }
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -94,18 +94,10 @@ public class WalletClientGatewayTest {
         .and().body("hsmId", equalTo("cbe80ad0-6a7d-4a5a-9891-8b4e95fa4d49"));
   }
 
-  @Test
-  void createsWalletUnitAttestation() {
-    walletClientGateway.tryCreateWalletUnitAttestation(session, null)
-        .then()
-        .assertThat().statusCode(201).and()
-        .body("jwt", matchesPattern("^[A-Za-z0-9]+\\.[A-Za-z0-9]+\\.[A-Za-z0-9\\-_]+$"));
-  }
-
   @ParameterizedTest
   @ValueSource(strings = {"nonce"})
   @NullSource
-  void createsWalletUnitAttestationWithAndWithoutNonce(String nonce) {
+  void createsWalletUnitAttestation(String nonce) {
     walletClientGateway.tryCreateWalletUnitAttestation(session, nonce)
         .then()
         .assertThat().statusCode(201).and()

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -29,7 +29,6 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -42,18 +41,15 @@ public class WalletClientGatewayTest {
 
   public static final String API_KEY = Optional.ofNullable(System.getenv(
       "DIGG_WALLET_ECOSYSTEM_WALLET_CLIENT_GATEWAY_API_KEY")).orElse("apikey");
-  private final WalletClientGatewayClient walletClientGateway = new WalletClientGatewayClient();
+  private static final WalletClientGatewayClient walletClientGateway =
+      new WalletClientGatewayClient();
   private static final String KEY_ID = "123";
-  private static ECKey ecKey;
   private static String session;
 
   @BeforeAll
   static void beforeAll() throws Exception {
-    ecKey = generateKey();
-  }
+    var ecKey = generateKey();
 
-  @BeforeEach
-  void createSession() throws Exception {
     var accountId = createAccountByApiKey(ecKey);
 
     assertAll(
@@ -181,7 +177,7 @@ public class WalletClientGatewayTest {
         .generate();
   }
 
-  private String createAccountByApiKey(ECKey ecKey) {
+  private static String createAccountByApiKey(ECKey ecKey) {
     var accountRequestBody = """
         {
           "personalIdentityNumber": "197001011234",

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -62,21 +62,7 @@ public class WalletClientGatewayTest {
 
   @BeforeEach
   void createSession() throws Exception {
-    var oidcSession = oidcLogin();
-
-    assertAll(
-        () -> assertNotNull(oidcSession),
-        () -> assertFalse(oidcSession.isEmpty()));
-
-    var accountId = walletClientGateway.createAccountByOidc(
-        """
-                {
-                  "emailAdress": "test@hej.se",
-                  "telephoneNumber": "070123123123",
-                  "publicKey": %s
-                }
-            """.formatted(ecKey.toPublicJWK().toJSONString()),
-        oidcSession);
+    var accountId = createAccountByOidc(ecKey);
 
     assertAll(
         () -> assertNotNull(accountId),
@@ -100,16 +86,7 @@ public class WalletClientGatewayTest {
 
   @Test
   void createAccount_usingApiKeyAuth_shouldReturnAccountId() throws Exception {
-    var ecKey = generateKey();
-    var accountRequestBody = """
-        {
-          "personalIdentityNumber": "197001011234",
-          "emailAdress": "test@hej.se",
-          "telephoneNumber": "070123123123",
-          "publicKey": %s
-        }""".formatted(ecKey.toPublicJWK().toJSONString());
-    var accountId = walletClientGateway.createAccountByApiKey(
-        accountRequestBody, API_KEY, "accounts");
+    var accountId = createAccountByApiKey(generateKey());
 
     assertAll(
         () -> assertNotNull(accountId),
@@ -120,15 +97,7 @@ public class WalletClientGatewayTest {
   void createAccountAndLoginWithChallenge_usingApiKey_shouldReturnSessionId() throws Exception {
     var ecKey = generateKey();
     // step one, create Account
-    var accountRequestBody = """
-        {
-          "personalIdentityNumber": "197001011234",
-          "emailAdress": "test@hej.se",
-          "telephoneNumber": "070123123123",
-          "publicKey": %s
-        }""".formatted(ecKey.toPublicJWK().toJSONString());
-    var accountId = walletClientGateway.createAccountByApiKey(
-        accountRequestBody, API_KEY, "accounts");
+    var accountId = createAccountByApiKey(ecKey);
 
     // step two, create challenge
     // use nonce to created signedJwt
@@ -208,6 +177,35 @@ public class WalletClientGatewayTest {
         .algorithm(Algorithm.NONE)
         .keyUse(KeyUse.SIGNATURE)
         .generate();
+  }
+
+  private String createAccountByApiKey(ECKey ecKey) {
+    var accountRequestBody = """
+        {
+          "personalIdentityNumber": "197001011234",
+          "emailAdress": "test@hej.se",
+          "telephoneNumber": "070123123123",
+          "publicKey": %s
+        }""".formatted(ecKey.toPublicJWK().toJSONString());
+    return walletClientGateway.createAccountByApiKey(
+        accountRequestBody, API_KEY, "accounts");
+  }
+
+  @Deprecated
+  private String createAccountByOidc(ECKey key) {
+    var oidcSession = oidcLogin();
+
+    assertAll(
+        () -> assertNotNull(oidcSession),
+        () -> assertFalse(oidcSession.isEmpty()));
+
+    return walletClientGateway.createAccountByOidc("""
+            {
+              "emailAdress": "test@hej.se",
+              "telephoneNumber": "070123123123",
+              "publicKey": %s
+            }
+        """.formatted(key.toPublicJWK().toJSONString()), oidcSession);
   }
 
   private String oidcLogin() {

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -64,12 +64,6 @@ public class WalletClientGatewayTest {
 
   @Test
   @Deprecated
-  void createAccount_usingOidc_shouldSucceed() {
-    assertDoesNotThrow(() -> createAccountByOidc(generateKey()));
-  }
-
-  @Test
-  @Deprecated
   void createAccountAndLoginWithChallenge_usingOidc_shouldSucceed() throws Exception {
     var ecKey = generateKey();
     // step one, create Account


### PR DESCRIPTION
We have reverted to using an API key for creating accounts. We already have test cases for checking account creation using API key and the now deprecated OIDC API. In this change set we update the tests so that most of our tests rely on account creation by API key and treat the OIDC way as a deprecated special case.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
