### PR TITLE
chore: bump wallet-attribute-attestation to v0.0.6

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -186,7 +186,7 @@ services:
       - wallet-ecosystem-network
 
   wallet-attribute-attestation:
-    image: ghcr.io/diggsweden/wallet-attribute-attestation:v0.0.5
+    image: ghcr.io/diggsweden/wallet-attribute-attestation:v0.0.6
     container_name: wallet-attribute-attestation
     hostname: wallet-attribute-attestation
     volumes:


### PR DESCRIPTION
See: https://github.com/diggsweden/wallet-attribute-attestation/releases/tag/v0.0.6

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
