### PR TITLE
fix: check for gommitlint instead of conform

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,7 +63,7 @@ setup-devtools:
 # Check required tools are installed
 [group('setup')]
 check-tools: _ensure-devtools
-    @{{devtools_dir}}/scripts/check-tools.sh --check-devtools mise git just java mvn rumdl yamlfmt actionlint gitleaks shellcheck shfmt conform reuse
+    @{{devtools_dir}}/scripts/check-tools.sh --check-devtools mise git just java mvn rumdl yamlfmt actionlint gitleaks shellcheck shfmt gommitlint reuse
 
 # Install tools via mise
 [group('setup')]


### PR DESCRIPTION
This fixes the check-tools step after we replaced conform with gommitlint.

See: diggsweden/devbase-check@f92943663eca5505238ecf3584fc155c3d739ee5

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
