### PR TITLE
fix: propagate maven exit code to just

### DIFF
--- a/justfile
+++ b/justfile
@@ -269,6 +269,7 @@ restart service:
 [group('test')]
 test:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Running" "mvn test"
     mvn {{maven_opts}} test
@@ -278,6 +279,7 @@ test:
 [group('test')]
 verify-maven:
     #!/usr/bin/env bash
+    set -euo pipefail
     source "{{colors}}"
     just_header "Running" "mvn verify"
     mvn {{maven_opts}} verify


### PR DESCRIPTION
Our maven commands are executed inside a separate bash shell. In order to propagate the exit status to just we need to set the `-e` flag. For good measure we include the whole 'strict mode' setting.

	set -euo pipefail

This ensures that the maven exit code is properly propagated to the invoking shell and enables command chaining based on the outcome, i.e.

	just test; and echo success; or echo failure

Without the fix, the command above would always print 'success' regardless of whether or not there are any test failures. With the fix, it would print 'success' if, and only if, all tests pass and 'false' otherwise.

One way to take advantage of this is to conditionally push your changes when all automated checks are successful:

	just test; and just verify; and git push

The command above will only push the local changes when all tests and all linter checks pass. Without the fix, the test step have no impact on the push and you stand the risk of pushing changes with test failures.

See: http://redsymbol.net/articles/unofficial-bash-strict-mode/

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
