### PR TITLE
fix: wait for services with healthchecks only

### DIFF
--- a/.github/workflows/reusable-integration.yml
+++ b/.github/workflows/reusable-integration.yml
@@ -95,13 +95,11 @@ jobs:
         run: |
           cd wallet-ecosystem
           echo "Waiting for services to become healthy..."
-
-          SERVICES_PATTERN=$(grep -E '^  [[:alnum:]-]+:' docker-compose.yaml | grep -v 'network' | sed 's|:||' | cut -d ' ' -f 3 | tr '\n' '|' | sed 's/|$//')
-          echo "Services to monitor: $SERVICES_PATTERN"
-
+          # Give services time to initialize (especially Keycloak)
           for i in {1..40}; do
             echo "Check attempt $i/40..."
-            UNHEALTHY=$(podman ps -a --format "{{.Names}} {{.Status}}" | grep -v "healthy" | grep -E "$SERVICES_PATTERN" || true)
+            # Get statuses of all containers that have health checks
+            UNHEALTHY=$(podman ps -a --format "{{.Names}} {{.Status}}" | grep -v "healthy" | grep -E "keycloak|wallet-client-gateway|wallet-attribute-attestation|wallet-account|valkey|db" || true)
             if [ -z "$UNHEALTHY" ]; then
               echo "All required services are healthy!"
               podman ps


### PR DESCRIPTION
This restores the behaviour we had before extracting the workflow from wallet-client-gateway and is an attempt to avoid a hopeless wait for service that never are listed as healthy.

Here is some sample output of the command `podman ps -a --format "{{.Names}} {{.Status}}"`:

	refimpl-verifier-backend Up About an hour
	wallet-provider Up About an hour
	wallet-attribute-attestation-db Up About an hour (healthy)
	wallet-account-db Up About an hour (healthy)
	wallet-client-gateway-valkey Up About an hour (healthy)
	keycloak Up About an hour (healthy)
	traefik Up About an hour
	demo-verifier Up About an hour
	pid-issuer Up About an hour
	wallet-attribute-attestation Up About an hour (healthy)
	wallet-account Up About an hour (healthy)
	wallet-client-gateway Up About an hour (healthy)

Here we can see a mix of services. All have been up for one hour, but it is only those that have a healthcheck defined in the compose file that are listed as healthy. Attempting to wait for the others to be marked as healthy is useless and will always lead to a timeout.

See: diggsweden/wallet-client-gateway@fc659ab614f8ff528bf263ecca1ab07ad90cd02f

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
