### PR TITLE
feat: disclaimer on user registration form

### DIFF
--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -2131,7 +2131,8 @@
       "requiredFields": "Obligatoriska fält",
       "error-user-attribute-required": "Vänligen fyll i fältet.",
       "acceptTerms": "Jag accepterar villkoren",
-      "termsAcceptanceRequired": "Du måste acceptera våra villkor"
+      "termsAcceptanceRequired": "Du måste acceptera våra villkor",
+      "termsText": "Jag är införstådd med att tjänsten är ett testsystem och att den tillhandahålls i befintligt skick, att fel och brister kan förekomma, samt att Digg inte tar något ansvar för eventuella skador uppkomna i samband med nyttjande av tjänsten. Jag förstår att allt mitt användande sker på egen risk."
     }
   },
   "authenticationFlows": [

--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -2129,7 +2129,9 @@
     "sv": {
       "registerTitle": "Registrera konto",
       "requiredFields": "Obligatoriska fält",
-      "error-user-attribute-required": "Vänligen fyll i fältet."
+      "error-user-attribute-required": "Vänligen fyll i fältet.",
+      "acceptTerms": "Jag accepterar villkoren",
+      "termsAcceptanceRequired": "Du måste acceptera våra villkor"
     }
   },
   "authenticationFlows": [

--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -2125,6 +2125,13 @@
   "internationalizationEnabled": true,
   "supportedLocales": ["sv"],
   "defaultLocale": "sv",
+  "localizationTexts": {
+    "sv": {
+      "registerTitle": "Registrera konto",
+      "requiredFields": "Obligatoriska fält",
+      "error-user-attribute-required": "Vänligen fyll i fältet."
+    }
+  },
   "authenticationFlows": [
     {
       "id": "4af945ea-3e65-4f7f-a853-347860806b47",

--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -2129,6 +2129,7 @@
   "localizationTexts": {
     "sv": {
       "registerTitle": "Registrera konto",
+      "registerMessage": "OBS! Ange inga känsliga uppgifter när du registrerar kontot.",
       "requiredFields": "Obligatoriska fält",
       "error-user-attribute-required": "Vänligen fyll i fältet.",
       "acceptTerms": "Jag accepterar villkoren",

--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -2591,6 +2591,14 @@
           "priority": 60,
           "autheticatorFlow": false,
           "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
         }
       ]
     },

--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -2123,6 +2123,7 @@
     ]
   },
   "internationalizationEnabled": true,
+  "loginTheme": "custom",
   "supportedLocales": ["sv"],
   "defaultLocale": "sv",
   "localizationTexts": {

--- a/config/keycloak/themes/custom/login/register.ftl
+++ b/config/keycloak/themes/custom/login/register.ftl
@@ -1,5 +1,6 @@
 <#--
 SPDX-FileCopyrightText: 2026 Keycloak Authors
+SPDX-FileCopyrightText: 2026 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: Apache-2.0
 -->
@@ -18,6 +19,15 @@ SPDX-License-Identifier: Apache-2.0
         <#else>
             ${msg("registerTitle")}
         </#if>
+    <#elseif section = "message">
+        <div class="${properties.kcAlertClass!} pf-m-warning">
+            <div class="${properties.kcAlertIconClass!}">
+                <span class="${properties.kcFeedbackWarningIcon!}"></span>
+            </div>
+            <span class="${properties.kcAlertTitleClass!} kc-feedback-text">
+                OBS! Ange inga känsliga uppgifter när du registrerar kontot.
+            </span>
+        </div>
     <#elseif section = "form">
         <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post" novalidate="novalidate">
             <@userProfileCommons.userProfileFormFields; callback, attribute>

--- a/config/keycloak/themes/custom/login/register.ftl
+++ b/config/keycloak/themes/custom/login/register.ftl
@@ -25,7 +25,7 @@ SPDX-License-Identifier: Apache-2.0
                 <span class="${properties.kcFeedbackWarningIcon!}"></span>
             </div>
             <span class="${properties.kcAlertTitleClass!} kc-feedback-text">
-                OBS! Ange inga känsliga uppgifter när du registrerar kontot.
+                ${msg("registerMessage")}
             </span>
         </div>
     <#elseif section = "form">

--- a/config/keycloak/themes/custom/login/register.ftl
+++ b/config/keycloak/themes/custom/login/register.ftl
@@ -1,0 +1,74 @@
+<#--
+SPDX-FileCopyrightText: 2026 Keycloak Authors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<#import "template.ftl" as layout>
+<#import "field.ftl" as field>
+<#import "user-profile-commons.ftl" as userProfileCommons>
+<#import "register-commons.ftl" as registerCommons>
+<#import "password-validation.ftl" as validator>
+<@layout.registrationLayout displayMessage=messagesPerField.exists('global') displayRequiredFields=true; section>
+<!-- template: register.ftl -->
+
+    <#if section = "header">
+        <#if messageHeader??>
+            ${kcSanitize(msg("${messageHeader}"))?no_esc}
+        <#else>
+            ${msg("registerTitle")}
+        </#if>
+    <#elseif section = "form">
+        <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post" novalidate="novalidate">
+            <@userProfileCommons.userProfileFormFields; callback, attribute>
+                <#if callback = "afterField">
+                <#-- render password fields just under the username or email (if used as username) -->
+                    <#if passwordRequired?? && (attribute.name == 'username' || (attribute.name == 'email' && realm.registrationEmailAsUsername))>
+                        <@field.password name="password" required=true label=msg("password") autocomplete="new-password" />
+                        <@field.password name="password-confirm" required=true label=msg("passwordConfirm") autocomplete="new-password" />
+                    </#if>
+                </#if>
+            </@userProfileCommons.userProfileFormFields>
+
+            <@registerCommons.termsAcceptance/>
+
+            <#if recaptchaRequired?? && (recaptchaVisible!false)>
+                <div class="form-group">
+                    <div class="${properties.kcInputWrapperClass!}">
+                        <div class="g-recaptcha" data-size="compact" data-sitekey="${recaptchaSiteKey}" data-action="${recaptchaAction}"></div>
+                    </div>
+                </div>
+            </#if>
+
+            <#if recaptchaRequired?? && !(recaptchaVisible!false)>
+                <script>
+                    function onSubmitRecaptcha(token) {
+                        document.getElementById("kc-register-form").requestSubmit();
+                    }
+                </script>
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <button class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!} g-recaptcha"
+                            data-sitekey="${recaptchaSiteKey}" data-callback="onSubmitRecaptcha" data-action="${recaptchaAction}" type="submit" id="kc-submit">
+                        ${msg("doRegister")}
+                    </button>
+                </div>
+            <#else>
+                <div id="kc-form-buttons" class="${properties.kcFormButtonsClass!}">
+                    <input class="${properties.kcButtonClass!} ${properties.kcButtonPrimaryClass!} ${properties.kcButtonBlockClass!} ${properties.kcButtonLargeClass!}" type="submit" value="${msg("doRegister")}"/>
+                </div>
+            </#if>
+
+            <div class="${properties.kcFormGroupClass!} pf-v5-c-login__main-footer-band">
+                <div id="kc-form-options" class="${properties.kcFormOptionsClass!} pf-v5-c-login__main-footer-band-item">
+                    <div class="${properties.kcFormOptionsWrapperClass!}">
+                        <span><a href="${url.loginUrl}">${kcSanitize(msg("backToLogin"))?no_esc}</a></span>
+                    </div>
+                </div>
+            </div>
+
+        </form>
+
+        <@validator.templates/>
+        <@validator.script field="password"/>
+    </#if>
+</@layout.registrationLayout>

--- a/config/keycloak/themes/custom/login/template.ftl
+++ b/config/keycloak/themes/custom/login/template.ftl
@@ -1,0 +1,269 @@
+<#--
+SPDX-FileCopyrightText: 2026 Keycloak Authors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<#import "field.ftl" as field>
+<#import "footer.ftl" as loginFooter>
+<#macro username>
+  <#assign label>
+    <#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>
+  </#assign>
+  <@field.group name="username" label=label>
+    <div class="${properties.kcInputGroup}">
+      <div class="${properties.kcInputGroupItemClass} ${properties.kcFill}">
+        <span class="${properties.kcInputClass} ${properties.kcFormReadOnlyClass}">
+          <input id="kc-attempted-username" value="${auth.attemptedUsername}" readonly>
+        </span>
+      </div>
+      <div class="${properties.kcInputGroupItemClass}">
+        <button id="reset-login" class="${properties.kcFormPasswordVisibilityButtonClass} kc-login-tooltip" type="button" 
+              aria-label="${msg('restartLoginTooltip')}" onclick="location.href='${url.loginRestartFlowUrl}'">
+            <i class="fa-sync-alt fas" aria-hidden="true"></i>
+            <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>
+        </button>
+      </div>
+    </div>
+  </@field.group>
+</#macro>
+
+<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false>
+<!DOCTYPE html>
+<html class="${properties.kcHtmlClass!}" lang="${lang}"<#if realm.internationalizationEnabled> dir="${(locale.rtl)?then('rtl','ltr')}"</#if>>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="color-scheme" content="light${darkMode?then(' dark', '')}">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <#if properties.meta?has_content>
+        <#list properties.meta?split(' ') as meta>
+            <meta name="${meta?split('==')[0]}" content="${meta?split('==')[1]}"/>
+        </#list>
+    </#if>
+    <title>${msg("loginTitle",(realm.displayName!''))}</title>
+    <link rel="icon" href="${url.resourcesPath}/img/favicon.ico" />
+    <#if properties.stylesCommon?has_content>
+        <#list properties.stylesCommon?split(' ') as style>
+            <link href="${url.resourcesCommonPath}/${style}" rel="stylesheet" />
+        </#list>
+    </#if>
+    <#if properties.styles?has_content>
+        <#list properties.styles?split(' ') as style>
+            <link href="${url.resourcesPath}/${style}" rel="stylesheet" />
+        </#list>
+    </#if>
+    <script type="importmap">
+        {
+            "imports": {
+                "rfc4648": "${url.resourcesCommonPath}/vendor/rfc4648/rfc4648.js"
+            }
+        }
+    </script>
+    <#if darkMode>
+      <script type="module" async blocking="render">
+          const DARK_MODE_CLASS = "${properties.kcDarkModeClass}";
+          const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+          updateDarkMode(mediaQuery.matches);
+          mediaQuery.addEventListener("change", (event) => updateDarkMode(event.matches));
+
+          function updateDarkMode(isEnabled) {
+            const { classList } = document.documentElement;
+
+            if (isEnabled) {
+              classList.add(DARK_MODE_CLASS);
+            } else {
+              classList.remove(DARK_MODE_CLASS);
+            }
+          }
+      </script>
+    </#if>
+    <#if properties.scripts?has_content>
+        <#list properties.scripts?split(' ') as script>
+            <script src="${url.resourcesPath}/${script}" type="text/javascript"></script>
+        </#list>
+    </#if>
+    <#if scripts??>
+        <#list scripts as script>
+            <script src="${script}" type="text/javascript"></script>
+        </#list>
+    </#if>
+    <script type="module" src="${url.resourcesPath}/js/passwordVisibility.js"></script>
+    <script type="module">
+        import { startSessionPolling } from "${url.resourcesPath}/js/authChecker.js";
+
+        startSessionPolling(
+            "${url.ssoLoginInOtherTabsUrl?no_esc}"
+        );
+    </script>
+    <script type="module">
+        document.addEventListener("click", (event) => {
+            const link = event.target.closest("a[data-once-link]");
+
+            if (!link) {
+                return;
+            }
+
+            if (link.getAttribute("aria-disabled") === "true") {
+                event.preventDefault();
+                return;
+            }
+
+            const { disabledClass } = link.dataset;
+
+            if (disabledClass) {
+                link.classList.add(...disabledClass.trim().split(/\s+/));
+            }
+
+            link.setAttribute("role", "link");
+            link.setAttribute("aria-disabled", "true");
+        });
+    </script>
+    <#if authenticationSession??>
+        <script type="module">
+            import { checkAuthSession } from "${url.resourcesPath}/js/authChecker.js";
+
+            checkAuthSession(
+                "${authenticationSession.authSessionIdHash}"
+            );
+        </script>
+    </#if>
+    <script>
+      // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1404468
+      const isFirefox = true;
+    </script>
+</head>
+
+<body id="keycloak-bg" class="${properties.kcBodyClass!}" data-page-id="login-${pageId}">
+<div class="${properties.kcLogin!}">
+  <div class="${properties.kcLoginContainer!}">
+    <header id="kc-header" class="pf-v5-c-login__header">
+      <div id="kc-header-wrapper"
+              class="pf-v5-c-brand">${kcSanitize(msg("loginTitleHtml",(realm.displayNameHtml!'')))?no_esc}</div>
+    </header>
+    <main class="${properties.kcLoginMain!}">
+      <div class="${properties.kcLoginMainHeader!}">
+        <h1 class="${properties.kcLoginMainTitle!}" id="kc-page-title"><#nested "header"></h1>
+        <#if realm.internationalizationEnabled  && locale.supported?size gt 1>
+        <div class="${properties.kcLoginMainHeaderUtilities!}">
+          <div class="${properties.kcInputClass!}">
+            <select
+              aria-label="${msg("languages")}"
+              id="login-select-toggle"
+              onchange="if (this.value) window.location.href=this.value"
+            >
+              <#list locale.supported?sort_by("label") as l>
+                <option
+                  value="${l.url}"
+                  ${(l.languageTag == locale.currentLanguageTag)?then('selected','')}
+                >
+                  ${l.label}
+                </option>
+              </#list>
+            </select>
+            <span class="${properties.kcFormControlUtilClass}">
+              <span class="${properties.kcFormControlToggleIcon!}">
+                <svg
+                  class="pf-v5-svg"
+                  viewBox="0 0 320 512"
+                  fill="currentColor"
+                  aria-hidden="true"
+                  role="img"
+                  width="1em"
+                  height="1em"
+                >
+                  <path
+                    d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                  >
+                  </path>
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+        </#if>
+      </div>
+      <div class="${properties.kcLoginMainBody!}">
+        <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
+            <#if displayRequiredFields>
+                <div class="${properties.kcContentWrapperClass!}">
+                    <div class="${properties.kcLabelWrapperClass!} subtitle">
+                        <span class="${properties.kcInputHelperTextItemTextClass!}">
+                          <span class="${properties.kcInputRequiredClass!}">*</span> ${msg("requiredFields")}
+                        </span>
+                    </div>
+                </div>
+            </#if>
+        <#else>
+            <#if displayRequiredFields>
+                <div class="${properties.kcContentWrapperClass!}">
+                    <div class="${properties.kcLabelWrapperClass!} subtitle">
+                        <span class="${properties.kcInputHelperTextItemTextClass!}">
+                          <span class="${properties.kcInputRequiredClass!}">*</span> ${msg("requiredFields")}
+                        </span>
+                    </div>
+                    <div class="${properties.kcFormClass} ${properties.kcContentWrapperClass}">
+                        <#nested "show-username">
+                        <@username />
+                    </div>
+                </div>
+            <#else>
+                <div class="${properties.kcFormClass} ${properties.kcContentWrapperClass}">
+                  <#nested "show-username">
+                  <@username />
+                </div>
+            </#if>
+        </#if>
+
+        <#-- App-initiated actions should not see warning messages about the need to complete the action -->
+        <#-- during login.                                                                               -->
+        <#if displayMessage && message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
+            <div class="${properties.kcAlertClass!} pf-m-${(message.type = 'error')?then('danger', message.type)}">
+                <div class="${properties.kcAlertIconClass!}">
+                    <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
+                    <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>
+                    <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>
+                    <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
+                </div>
+                <span class="${properties.kcAlertTitleClass!} kc-feedback-text">${kcSanitize(message.summary)?no_esc}</span>
+            </div>
+        </#if>
+
+        <#nested "form">
+
+        <#if auth?has_content && auth.showTryAnotherWayLink()>
+          <form id="kc-select-try-another-way-form" action="${url.loginAction}" method="post" novalidate="novalidate">
+              <input type="hidden" name="tryAnotherWay" value="on"/>
+              <a id="try-another-way" href="javascript:document.forms['kc-select-try-another-way-form'].requestSubmit()"
+                  class="${properties.kcButtonSecondaryClass} ${properties.kcButtonBlockClass} ${properties.kcMarginTopClass}">
+                    ${kcSanitize(msg("doTryAnotherWay"))?no_esc}
+              </a>
+          </form>
+        </#if>
+
+          <div class="${properties.kcLoginMainFooter!}">
+              <#nested "socialProviders">
+
+              <#if displayInfo>
+                  <div id="kc-info" class="${properties.kcLoginMainFooterBand!} ${properties.kcFormClass}">
+                      <div id="kc-info-wrapper" class="${properties.kcLoginMainFooterBandItem!}">
+                          <#nested "info">
+                      </div>
+                  </div>
+              </#if>
+          </div>
+      </div>
+
+        <div class="${properties.kcLoginMainFooter!}">
+            <@loginFooter.content/>
+        </div>
+    </main>
+  </div>
+</div>
+</body>
+</html>
+</#macro>

--- a/config/keycloak/themes/custom/login/template.ftl
+++ b/config/keycloak/themes/custom/login/template.ftl
@@ -1,5 +1,6 @@
 <#--
 SPDX-FileCopyrightText: 2026 Keycloak Authors
+SPDX-FileCopyrightText: 2026 The Wallet Ecosystem Authors
 
 SPDX-License-Identifier: Apache-2.0
 -->
@@ -188,6 +189,7 @@ SPDX-License-Identifier: Apache-2.0
         </#if>
       </div>
       <div class="${properties.kcLoginMainBody!}">
+        <#nested "message">
         <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
             <#if displayRequiredFields>
                 <div class="${properties.kcContentWrapperClass!}">

--- a/config/keycloak/themes/custom/login/theme.properties
+++ b/config/keycloak/themes/custom/login/theme.properties
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 The Wallet Ecosystem Authors
+#
+# SPDX-License-Identifier: EUPL-1.2
+parent=keycloak.v2

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -356,6 +356,7 @@ services:
     volumes:
       - ./config/keycloak/extra/health-check.sh:/opt/keycloak/health-check.sh
       - ./config/keycloak/realms/:/opt/keycloak/data/import
+      - ./config/keycloak/themes/:/opt/keycloak/themes
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.keycloak.rule=PathPrefix(`/idp`)"


### PR DESCRIPTION
Here we ask the user to not enter any sensitive information in the Keycloak user registration form. We also require the user to accept our terms and conditions.

<img width="49%" alt="keycloak-registration-message-2026-04-02" src="https://github.com/user-attachments/assets/0f57ee3d-baf6-42e6-91f2-fd2910d1c7ea" />
<img width="49%" alt="keycloak-registration-terms-2026-04-02" src="https://github.com/user-attachments/assets/244940fa-3ec9-449f-b7f0-15805746d06d" />

The files in the `./config/keycloak/themes` directory are a copy of the corresponding files in the "keycloak.v2" theme bundled in the keycloak container image. These have all been modified with a SPDX license header corresponding to the Apache 2.0 license of Keycloak. The few theme files that have additional changes all have an additional license line referring to the Wallet Ecosystem Authors.

To test the changes, start the ecosystem and [navigate to the PID issuer realm login](https://localhost/idp/realms/pid-issuer-realm/account/). Then click the registration link at the bottom of the page.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
