### PR TITLE
fix: consider all services in service wait

### DIFF
--- a/.github/workflows/reusable-integration.yml
+++ b/.github/workflows/reusable-integration.yml
@@ -7,6 +7,11 @@ name: Reusable Ecosystem Integration
 on:
   workflow_call:
     inputs:
+      ecosystem-ref:
+        required: false
+        type: string
+        default: ''
+        description: "Git ref to checkout for wallet ecosystem (e.g., refs/pull/1/merge)"
       service-name:
         required: true
         type: string
@@ -43,6 +48,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: diggsweden/wallet-ecosystem
+          ref: ${{ inputs.ecosystem-ref }}
           path: wallet-ecosystem
 
       - name: Checkout Service (${{ inputs.service-name }})

--- a/.github/workflows/reusable-integration.yml
+++ b/.github/workflows/reusable-integration.yml
@@ -105,24 +105,7 @@ jobs:
       - name: Wait for Services to be Healthy
         run: |
           cd wallet-ecosystem
-          echo "Waiting for services to become healthy..."
-          # Give services time to initialize (especially Keycloak)
-          for i in {1..40}; do
-            echo "Check attempt $i/40..."
-            # Get statuses of all containers that have health checks
-            UNHEALTHY=$(podman ps -a --format "{{.Names}} {{.Status}}" | grep -v "healthy" | grep -E "keycloak|wallet-client-gateway|wallet-attribute-attestation|wallet-account|valkey|db" || true)
-            if [ -z "$UNHEALTHY" ]; then
-              echo "All required services are healthy!"
-              podman ps
-              exit 0
-            fi
-            echo "Waiting for services: $UNHEALTHY"
-            sleep 10
-          done
-          echo "Timeout waiting for services to become healthy"
-          podman ps
-          podman compose logs
-          exit 1
+          ./wait-until-healthy.sh
 
       - name: Run Ecosystem Integration Tests
         env:

--- a/wait-until-healthy.sh
+++ b/wait-until-healthy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+echo "Waiting for services to become healthy..."
+# Give services time to initialize (especially Keycloak)
+for i in {1..40}; do
+  echo "Check attempt $i/40..."
+  # Get statuses of all containers that have health checks
+  UNHEALTHY=$(podman ps -a --format "{{.Names}} {{.Status}}" | grep -v "healthy" | grep -E "keycloak|wallet-client-gateway|wallet-attribute-attestation|wallet-account|valkey|db" || true)
+  if [ -z "$UNHEALTHY" ]; then
+    echo "All required services are healthy!"
+    podman ps
+    exit 0
+  fi
+  echo "Waiting for services: $UNHEALTHY"
+  sleep 10
+done
+echo "Timeout waiting for services to become healthy"
+podman ps
+podman compose logs
+exit 1

--- a/wait-until-healthy.sh
+++ b/wait-until-healthy.sh
@@ -5,11 +5,19 @@
 # SPDX-License-Identifier: EUPL-1.2
 
 echo "Waiting for services to become healthy..."
+REGEX_FOR_ALL_SERVICES=$(yq -r '.services | to_entries | .[].key' docker-compose.yaml | sort | xargs | tr ' ' '|')
+REGEX_FOR_SERVICES_WITH_HEALTH_CHECKS='(keycloak|wallet-client-gateway|wallet-attribute-attestation|wallet-account|valkey|db) .*healthy'
+REGEX_FOR_INIT_CONTAINERS='keycloak-init Exited \(0\)'
+REGEX_FOR_OTHERS='(refimpl-verifier-backend|wallet-provider|pid-issuer|traefik|demo-verifier) Up'
 # Give services time to initialize (especially Keycloak)
 for i in {1..40}; do
   echo "Check attempt $i/40..."
   # Get statuses of all containers that have health checks
-  UNHEALTHY=$(podman ps -a --format "{{.Names}} {{.Status}}" | grep -v "healthy" | grep -E "keycloak|wallet-client-gateway|wallet-attribute-attestation|wallet-account|valkey|db" || true)
+  UNHEALTHY=$(
+    podman ps -a --format "{{.Names}} {{.Status}}" |
+      grep -E "$REGEX_FOR_ALL_SERVICES" |
+      grep -v -E "($REGEX_FOR_SERVICES_WITH_HEALTH_CHECKS)|($REGEX_FOR_INIT_CONTAINERS)|($REGEX_FOR_OTHERS)" || true
+  )
   if [ -z "$UNHEALTHY" ]; then
     echo "All required services are healthy!"
     podman ps


### PR DESCRIPTION
After adding the 'keycloak-init' container to our docker-compose.yaml
the service wait breaks because the container is never healthy. An init
container is considered successful if it has exited with a zero exit
code.

To fix this problem we change the logic to check for the specific
success state of each known service.

 1. For services with health checks, we expect a status of 'healthy'
 2. For init containers, we expect a status of 'Exited (0)'
 3. For all other services, we expect a status of 'Up'

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
