### PR TITLE
test: generate natural display names

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -23,9 +23,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class EndToEndTest {
 
   private final VerifierBackendClient verifierBackend = new VerifierBackendClient();

--- a/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/EndToEndTest.java
@@ -23,12 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 
-@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
+@DisplayName("The wallet ecosystem")
 public class EndToEndTest {
 
   private final VerifierBackendClient verifierBackend = new VerifierBackendClient();

--- a/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/KeycloakTest.java
@@ -12,12 +12,15 @@ import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class KeycloakTest {
 
   private final KeycloakClient keycloak = new KeycloakClient();

--- a/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategyTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/MetadataLocationStrategyTest.java
@@ -11,10 +11,13 @@ import static se.digg.wallet.ecosystem.MetadataLocationStrategy.OID4VCI_COMPLIAN
 
 import java.net.URI;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 class MetadataLocationStrategyTest {
 
   public static Stream<Arguments> uriExamples() {

--- a/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGenerator.java
+++ b/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGenerator.java
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.DisplayNameGenerator;
+
+
+
+public class NaturalDisplayNameGenerator implements DisplayNameGenerator {
+  private static final Pattern WORD_BOUNDARY_PATTERN =
+      Pattern.compile("([A-Z](?=[^A-Z]))|([A-Z]+(?=[A-Z]))|[0-9]+|_");
+
+  @Override
+  @NonNull
+  public String generateDisplayNameForClass(@NonNull Class<?> testClass) {
+    return "The " + toSpaceSeparatedWords(extractSubject(testClass.getSimpleName()));
+  }
+
+  @Override
+  @NonNull
+  public String generateDisplayNameForNestedClass(
+      @NonNull List<Class<?>> enclosingInstanceTypes, Class<?> nestedClass) {
+    return toSpaceSeparatedWords(nestedClass.getSimpleName());
+  }
+
+  @Override
+  @NonNull
+  public String generateDisplayNameForMethod(@NonNull List<Class<?>> enclosingInstanceTypes,
+      @NonNull Class<?> testClass, Method testMethod) {
+    return toSpaceSeparatedWords(testMethod.getName());
+  }
+
+  private static @NonNull String extractSubject(String text) {
+    if (!text.endsWith("Test")) {
+      return text;
+    } else {
+      return text.substring(0, text.lastIndexOf("Test"));
+    }
+  }
+
+  private static @NonNull String toSpaceSeparatedWords(String text) {
+    return WORD_BOUNDARY_PATTERN.matcher(text)
+        .replaceAll(match -> {
+          if (match.group().equals("_")) {
+            return " ";
+          } else if (match.group().length() == 1) {
+            return " " + match.group().toLowerCase();
+          } else {
+            return " " + match.group();
+          }
+        }).stripLeading();
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGeneratorTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGeneratorTest.java
@@ -7,13 +7,10 @@ package se.digg.wallet.ecosystem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 class NaturalDisplayNameGeneratorTest {
 
   private static class FooTest {

--- a/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGeneratorTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGeneratorTest.java
@@ -7,10 +7,13 @@ package se.digg.wallet.ecosystem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 class NaturalDisplayNameGeneratorTest {
 
   private static class FooTest {

--- a/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGeneratorTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/NaturalDisplayNameGeneratorTest.java
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+//
+// SPDX-License-Identifier: EUPL-1.2
+
+package se.digg.wallet.ecosystem;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class NaturalDisplayNameGeneratorTest {
+
+  private static class FooTest {
+    void acceptsValidInput() {}
+
+    void rejectsInvalidInput() {}
+
+    void understandsNumbersLikeA5OutOf100() {}
+
+    void understands_snake_case() {}
+  }
+
+  private static class BarTest {
+  }
+
+  private static class ClassWithMultipleWordsTest {
+  }
+
+  private static class ClassWithTestInTheMiddle {
+  }
+
+  private static class TestTest {
+  }
+
+  private static class Foo {
+  }
+
+  private static class FooBar {
+  }
+
+  private static class AcronymABCTest {
+  }
+
+  private static class AcronymABCWithMoreWordsTest {
+  }
+
+  private static class NestedTest {
+    private static class NestedAtLevelOne {
+      private static class NestedAtLevelTwo {
+        void aNestedTestMethod() {}
+      }
+    }
+  }
+
+  private final NaturalDisplayNameGenerator subject = new NaturalDisplayNameGenerator();
+
+  @ParameterizedTest
+  @CsvSource({
+      "FooTest, The foo",
+      "BarTest, The bar",
+      "ClassWithMultipleWordsTest, The class with multiple words",
+      "ClassWithTestInTheMiddle, The class with test in the middle",
+      "TestTest, The test",
+      "AcronymABCTest, The acronym ABC",
+      "AcronymABCWithMoreWordsTest, The acronym ABC with more words",
+      "Foo, The foo",
+      "FooBar, The foo bar"
+  })
+  void producesNameForClassByTokenizingSimpleName(String className, String expectedName)
+      throws ClassNotFoundException {
+    assertEquals(expectedName, subject.generateDisplayNameForClass(
+        Class.forName(NaturalDisplayNameGeneratorTest.class.getName() + "$" + className)));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+      "FooTest, acceptsValidInput, accepts valid input",
+      "FooTest, rejectsInvalidInput, rejects invalid input",
+      "FooTest, understandsNumbersLikeA5OutOf100, understands numbers like a 5 out of 100",
+      "FooTest, understands_snake_case, understands snake case",
+  })
+  void producesNameForMethodByTokenizingMethodName(
+      String className, String methodName, String expectedName)
+      throws NoSuchMethodException, ClassNotFoundException {
+
+    Class<?> theClass =
+        Class.forName(NaturalDisplayNameGeneratorTest.class.getName() + "$" + className);
+
+    assertEquals(expectedName,
+        subject.generateDisplayNameForMethod(List.of(), theClass,
+            theClass.getDeclaredMethod(methodName)));
+  }
+
+  @Test
+  void producesNameForNestedClassByTokenizingSimpleName() {
+    assertEquals("nested at level one",
+        subject.generateDisplayNameForNestedClass(List.of(), NestedTest.NestedAtLevelOne.class));
+  }
+}

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -19,12 +19,15 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class PidIssuerTest {
 
   private static final ServiceIdentifier IDENTIFIER = ServiceIdentifier.PID_ISSUER;

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -19,15 +19,12 @@ import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
-@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class PidIssuerTest {
 
   private static final ServiceIdentifier IDENTIFIER = ServiceIdentifier.PID_ISSUER;

--- a/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/PidIssuerTest.java
@@ -61,7 +61,7 @@ public class PidIssuerTest {
   @ParameterizedTest
   @MethodSource("usefulLinks")
   @MethodSource("authorizationServers")
-  void linkWorks(String labelNotUsedInTestButIncludedInDisplayName, String link) {
+  void servesWorkingLinks(String labelNotUsedInTestButIncludedInDisplayName, String link) {
     given().when().get(link).then().assertThat().statusCode(200);
   }
 
@@ -106,7 +106,7 @@ public class PidIssuerTest {
   }
 
   @Test
-  void getNonce() throws Exception {
+  void producesNonceWhenGivenValidAccessTokenAndProof() throws Exception {
     ECKey userJwk = new ECKeyGenerator(Curve.P_256).generate();
 
     // 1. Get access token for user

--- a/src/test/java/se/digg/wallet/ecosystem/ServiceIdentifierTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/ServiceIdentifierTest.java
@@ -21,8 +21,11 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 class ServiceIdentifierTest {
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/TraefikTest.java
@@ -7,8 +7,11 @@ package se.digg.wallet.ecosystem;
 import static org.hamcrest.Matchers.is;
 import static se.digg.wallet.ecosystem.RestAssuredSugar.given;
 
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class TraefikTest {
 
   @Test

--- a/src/test/java/se/digg/wallet/ecosystem/VerifierBackendTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/VerifierBackendTest.java
@@ -21,10 +21,13 @@ import io.restassured.response.Response;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 class VerifierBackendTest {
   private static final String dcqlId = UUID.randomUUID().toString();
   private final String nonce = UUID.randomUUID().toString();

--- a/src/test/java/se/digg/wallet/ecosystem/VerifierFrontendTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/VerifierFrontendTest.java
@@ -12,10 +12,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.restassured.response.Response;
 import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 class VerifierFrontendTest {
 
   static final List<String> SITE_NAMES = List.of("vaccincentralen", "matcentralen");

--- a/src/test/java/se/digg/wallet/ecosystem/WalletAccountTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletAccountTest.java
@@ -17,8 +17,11 @@ import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import io.restassured.http.ContentType;
 import java.util.UUID;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class WalletAccountTest {
 
   private static final String BASE = "https://localhost/wallet-account";

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -25,6 +25,8 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -33,6 +35,7 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @TestMethodOrder(OrderAnnotation.class)
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class WalletClientGatewayTest {
 
   private static final String API_KEY = Optional.ofNullable(System.getenv(

--- a/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletProviderTest.java
@@ -10,11 +10,14 @@ import static org.hamcrest.Matchers.matchesPattern;
 
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@DisplayNameGeneration(DisplayNameGenerator.Standard.class)
 public class WalletProviderTest {
 
   private final WalletProviderClient walletProvider = new WalletProviderClient();

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+junit.jupiter.displayname.generator.default=se.digg.wallet.ecosystem.NaturalDisplayNameGenerator


### PR DESCRIPTION
Here we add a way to produce test names that are mora natural looking than the standard `CamelCase`.

We do this by splitting the original test names at the camel case word boundaries and replacing the initial capital letter with a space. Special care is taken for numbers and acronyms (consecutive sequences of capital letters). Also, the class name is given special treatment where we remove the "Test" suffix and insert the word "The".

All in all, this leads to a test report that looks like this:

> The pid issuer
>     - presents useful links
>     - serves credential issuer metadata
>     - serves jwt issuer metadata
>     - serves working links
>     - serves metadata with logo
>     - produces nonce given valid access token and proof

Without this change, the test report looks like this:

> PidIssuerTest
>     - presentsUsefulLinks
>     - servesCredentialIssuerMetadata
>     - servesJwtIssuerMetadata
>     - servesWorkingLinks
>     - servesMetadataWithLogo
>     - producesNonceGivenValidAccessTokenAndProof

<img width="1352" height="848" alt="natural-test-names-2026-04-27" src="https://github.com/user-attachments/assets/b15f938d-16a5-493b-b5e8-40aef7448a26" />

The new naming strategy is enabled by default, but has been explicitly disabled for all existing tests except `PidIssuerTest` and the tests for the new class `NaturalDisplayNameGenerator`.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
