### PR TITLE
chore: bump wallet-client-gateway to v0.5.2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -258,13 +258,13 @@ services:
       - wallet-ecosystem-network
 
   wallet-client-gateway:
-    image: ghcr.io/diggsweden/wallet-client-gateway:v0.5.1
+    image: ghcr.io/diggsweden/wallet-client-gateway:v0.5.2
     container_name: wallet-client-gateway
     hostname: wallet-client-gateway
     volumes:
       - ./config/common/Healthcheck.class:/opt/Healthcheck.class:ro
     environment:
-      LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_SECURITY: DEBUG
+      LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_SECURITY: INFO
       SERVER_SERVLET_CONTEXT_PATH: "/wallet-client-gateway"
       SPRING_PROFILES_ACTIVE: "prod"
       TZ: "Europe/Stockholm"


### PR DESCRIPTION
# Pull Request Description

Bump wallet-client-gateway to v0.5.2 (with request-response logging).
Set spring-security log level to INFO for wallet-client-gateway in docker compose.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
