### PR TITLE
feat(keycloak): disable passkey login

### DIFF
--- a/config/keycloak/realms/pid-issuer-realm-realm.json
+++ b/config/keycloak/realms/pid-issuer-realm-realm.json
@@ -489,7 +489,7 @@
   "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
   "webAuthnPolicyPasswordlessAcceptableAaguids": [],
   "webAuthnPolicyPasswordlessExtraOrigins": [],
-  "webAuthnPolicyPasswordlessPasskeysEnabled": true,
+  "webAuthnPolicyPasswordlessPasskeysEnabled": false,
   "scopeMappings": [
     {
       "clientScope": "eu.europa.ec.eudi.pid_vc_sd_jwt",


### PR DESCRIPTION
We don't use this kind of login so we want to remove it in order to reduce clutter on the login screen.

## Before change
<img width="788" height="775" alt="keycloak-login-with-passkey-option-2026-05-13" src="https://github.com/user-attachments/assets/50f1bee3-82d4-46c6-9016-bd7a420d8bdb" />

## After change
<img width="788" height="775" alt="keycloak-login-no-passkey-option-2026-05-13" src="https://github.com/user-attachments/assets/1ebb09f9-03df-4e7f-8bf2-c6eba3e6bca0" />

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
