### PR TITLE
refactor:cleanup gateway client

### DIFF
--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -12,10 +12,13 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import java.net.URI;
+import java.util.Optional;
 
 public class WalletClientGatewayClient {
 
   private final URI base = ServiceIdentifier.WALLET_CLIENT_GATEWAY.getResourceRoot();
+  private static final String API_KEY = Optional.ofNullable(System.getenv(
+      "DIGG_WALLET_ECOSYSTEM_WALLET_CLIENT_GATEWAY_API_KEY")).orElse("apikey");
 
   public Response tryGetHealth() {
     return given()
@@ -23,11 +26,11 @@ public class WalletClientGatewayClient {
         .get(base.resolve("actuator/health"));
   }
 
-  public String createAccountByApiKey(String postBody, String apiKey) {
+  public String createAccount(String postBody) {
     return given()
         .when()
         .contentType(ContentType.JSON).body(postBody)
-        .header("X-API-KEY", apiKey)
+        .header("X-API-KEY", API_KEY)
         .post(base.resolve("v0/accounts"))
         .then()
         .assertThat().statusCode(201)
@@ -35,25 +38,25 @@ public class WalletClientGatewayClient {
         .extract().body().jsonPath().getString("accountId");
   }
 
-  public void addWalletKey(String sessionId, String apiKey, String keyBody) {
+  public void addWalletKey(String sessionId, String keyBody) {
     given()
         .when()
         .contentType(ContentType.JSON)
         .body(keyBody)
         .header("Session", sessionId)
-        .header("X-API-KEY", apiKey)
+        .header("X-API-KEY", API_KEY)
         .post(base.resolve("v0/accounts/wallet-keys"))
         .then()
         .assertThat().statusCode(201);
   }
 
-  public void addSecurityEnvelope(String sessionId, String apiKey, String keyBody) {
+  public void addSecurityEnvelope(String sessionId, String keyBody) {
     given()
         .when()
         .contentType(ContentType.JSON)
         .body(keyBody)
         .header("Session", sessionId)
-        .header("X-API-KEY", apiKey)
+        .header("X-API-KEY", API_KEY)
         .post(base.resolve("v0/accounts/security-envelopes"))
         .then()
         .assertThat().statusCode(201);

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayClient.java
@@ -23,12 +23,12 @@ public class WalletClientGatewayClient {
         .get(base.resolve("actuator/health"));
   }
 
-  public String createAccountByApiKey(String postBody, String apiKey, String path) {
+  public String createAccountByApiKey(String postBody, String apiKey) {
     return given()
         .when()
         .contentType(ContentType.JSON).body(postBody)
         .header("X-API-KEY", apiKey)
-        .post(base.resolve(path))
+        .post(base.resolve("v0/accounts"))
         .then()
         .assertThat().statusCode(201)
         .and().body("accountId", not(blankOrNullString()))

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -64,7 +64,7 @@ public class WalletClientGatewayTest {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0Request(ecKey);
     var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY, "v0/accounts");
+        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
@@ -73,7 +73,7 @@ public class WalletClientGatewayTest {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0Request(ecKey);
     var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY, "v0/accounts");
+        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
@@ -82,7 +82,7 @@ public class WalletClientGatewayTest {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0RequestWithNullPersonalIdentityNumber(ecKey);
     var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY, "v0/accounts");
+        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
@@ -91,7 +91,7 @@ public class WalletClientGatewayTest {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0RequestWithOnlyDeviceKey(ecKey);
     var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY, "v0/accounts");
+        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
@@ -145,7 +145,7 @@ public class WalletClientGatewayTest {
   private static String createAccountByApiKey(ECKey ecKey) {
     var accountRequestBody = stubAccountV0Request(ecKey);
     return walletClientGateway.createAccountByApiKey(
-        accountRequestBody, API_KEY, "v0/accounts");
+        accountRequestBody, API_KEY);
   }
 
   private static String stubAccountV0Request(ECKey ecKey) {

--- a/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
+++ b/src/test/java/se/digg/wallet/ecosystem/WalletClientGatewayTest.java
@@ -22,7 +22,6 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.util.Date;
-import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -35,8 +34,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 @TestMethodOrder(OrderAnnotation.class)
 public class WalletClientGatewayTest {
 
-  private static final String API_KEY = Optional.ofNullable(System.getenv(
-      "DIGG_WALLET_ECOSYSTEM_WALLET_CLIENT_GATEWAY_API_KEY")).orElse("apikey");
   private static final WalletClientGatewayClient walletClientGateway =
       new WalletClientGatewayClient();
   private static final String KEY_ID = "123";
@@ -45,7 +42,7 @@ public class WalletClientGatewayTest {
   @BeforeAll
   static void beforeAll() throws Exception {
     var ecKey = generateKey();
-    var accountId = createAccountByApiKey(ecKey);
+    var accountId = createAccount(ecKey);
     var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
     var signedJwt = createSignedJwt(ecKey, nonce);
     session = walletClientGateway.respondToChallenge(signedJwt);
@@ -63,8 +60,7 @@ public class WalletClientGatewayTest {
   void createAccount_should_return_accountId() throws Exception {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0Request(ecKey);
-    var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
+    var accountId = walletClientGateway.createAccount(accountRequestBody);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
@@ -72,8 +68,7 @@ public class WalletClientGatewayTest {
   void createAccountv0_should_return_accountId() throws Exception {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0Request(ecKey);
-    var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
+    var accountId = walletClientGateway.createAccount(accountRequestBody);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
@@ -82,7 +77,7 @@ public class WalletClientGatewayTest {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0RequestWithNullPersonalIdentityNumber(ecKey);
     var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
+        walletClientGateway.createAccount(accountRequestBody);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
@@ -90,22 +85,21 @@ public class WalletClientGatewayTest {
   void createAccountv0WithOnlyDeviceKey_should_return_accountId() throws Exception {
     var ecKey = generateKey();
     var accountRequestBody = stubAccountV0RequestWithOnlyDeviceKey(ecKey);
-    var accountId =
-        walletClientGateway.createAccountByApiKey(accountRequestBody, API_KEY);
+    var accountId = walletClientGateway.createAccount(accountRequestBody);
     assertThat("accountId should be UUID", UUID.fromString(accountId), instanceOf(UUID.class));
   }
 
   @Test
   void addWalletKey_should_return_201() throws Exception {
     var walletKey = generateKey();
-    walletClientGateway.addWalletKey(session, API_KEY, walletKey.toPublicJWK().toJSONString());
+    walletClientGateway.addWalletKey(session, walletKey.toPublicJWK().toJSONString());
   }
 
   @Test
   void addSecurityEnvelope_should_return_201() {
     var securityEnvelopeRequest = createSecurityEnvelopeRequest("SIGN",
         "This is a string representation of a Blob");
-    walletClientGateway.addSecurityEnvelope(session, API_KEY, securityEnvelopeRequest);
+    walletClientGateway.addSecurityEnvelope(session, securityEnvelopeRequest);
   }
 
   @ParameterizedTest
@@ -113,12 +107,12 @@ public class WalletClientGatewayTest {
   @NullSource
   void createWalletUnitAttestation(String wuaNonce) throws Exception {
     var ecKey = generateKey();
-    var accountId = createAccountByApiKey(ecKey);
+    var accountId = createAccount(ecKey);
     var nonce = walletClientGateway.initChallenge(accountId, KEY_ID);
     var signedJwt = createSignedJwt(ecKey, nonce);
     var session = walletClientGateway.respondToChallenge(signedJwt);
     var walletKey = generateKey();
-    walletClientGateway.addWalletKey(session, API_KEY, walletKey.toPublicJWK().toJSONString());
+    walletClientGateway.addWalletKey(session, walletKey.toPublicJWK().toJSONString());
 
     walletClientGateway.tryCreateWalletUnitAttestation(session, wuaNonce)
         .then()
@@ -142,10 +136,9 @@ public class WalletClientGatewayTest {
         .generate();
   }
 
-  private static String createAccountByApiKey(ECKey ecKey) {
+  private static String createAccount(ECKey ecKey) {
     var accountRequestBody = stubAccountV0Request(ecKey);
-    return walletClientGateway.createAccountByApiKey(
-        accountRequestBody, API_KEY);
+    return walletClientGateway.createAccount(accountRequestBody);
   }
 
   private static String stubAccountV0Request(ECKey ecKey) {


### PR DESCRIPTION
Here we do some cleanup of the `WalletClientGatewayClient`related to creating accounts.

 1. The path parameter always has the same value "/v0/accounts", so we inline it into the method body
 2. The API key is moved from the test to the client to simplify the test code

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
